### PR TITLE
[HLAPI] (Un)Modified-Since Preconditions

### DIFF
--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -9020,12 +9020,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AbstractController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Controller\\\\AbstractController\\:\\:getErrorResponseBody\\(\\) has parameter \\$detail with no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AbstractController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Controller\\\\AbstractController\\:\\:getKnownSchema\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -5276,12 +5276,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/Deprecated/TicketFollowup.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Controller\\\\AbstractController\\:\\:getErrorResponseBody\\(\\) should return array\\{status\\: string, title\\: string, detail\\: string\\|null, additional_messages\\?\\: array\\<array\\{priority\\: string, message\\: string\\}\\>\\} but returns array\\{status\\: \'ERROR\'\\|\'ERROR_ALREADY_EXISTS\'\\|\'ERROR_BAD_ARRAY\'\\|\'ERROR_INVALID…\'\\|\'ERROR_ITEM_NOT_FOUND\'\\|\'ERROR_METHOD_NOT…\'\\|\'ERROR_RIGHT_MISSING\'\\|\'ERROR_SESSION_TOKEN…\', title\\: string, detail\\: array\\|string\\|null, additional_messages\\?\\: non\\-empty\\-array\\<array\\{priority\\: string, message\\: string\\}\\>\\}\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AbstractController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$headers of class Glpi\\\\Http\\\\Response constructor expects array\\<array\\<string\\>\\|string\\>, array\\<string, list\\<string\\|null\\>\\> given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The present file will list all changes made to the project; according to the
 ## [11.0.9] unreleased
 
 ### Added
+- New schemas/endpoints for Service Catalog information in High-Level API v2.4.
+- New schemas/endpoints for reminder translations in High-Level API v2.4.
+- New endpoints for viewing, adding and deleting emails for other users in High-Level API v2.4.
+- Endpoints to add or remove relations for links between assets and appliances in High-Level API v2.4.
+- New schemas/endpoints for custom asset definitions and fields in High-Level API v2.4.
+- New schema/endpoints to view and change Kanban view state data in High-Level API v2.4.
+- `supervisor` property added for `User` schema in High-Level API v2.4.
+- Support for `If-Modified-Since` and `If-Unmodified-Since` HTTP headers for resource update requests in High-Level API. This is not controlled by the API version.
 
 ### Changed
 - Fixed searching values with multiple concurrent spaces.
@@ -30,13 +38,6 @@ The present file will list all changes made to the project; according to the
 ## [11.0.8] 2026-06-24
 
 ### Added
-- New schemas/endpoints for Service Catalog information in High-Level API v2.4.
-- New schemas/endpoints for reminder translations in High-Level API v2.4.
-- New endpoints for viewing, adding and deleting emails for other users in High-Level API v2.4.
-- Endpoints to add or remove relations for links between assets and appliances in High-Level API v2.4.
-- New schemas/endpoints for custom asset definitions and fields in High-Level API v2.4.
-- New schema/endpoints to view and change Kanban view state data in High-Level API v2.4.
-- `supervisor` property added for `User` schema in High-Level API v2.4.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The present file will list all changes made to the project; according to the
 - New schemas/endpoints for custom asset definitions and fields in High-Level API v2.4.
 - New schema/endpoints to view and change Kanban view state data in High-Level API v2.4.
 - `supervisor` property added for `User` schema in High-Level API v2.4.
-- Support for `If-Modified-Since` and `If-Unmodified-Since` HTTP headers for resource update requests in High-Level API. This is not controlled by the API version.
+- Support for `If-Modified-Since` and `If-Unmodified-Since` HTTP headers for some types of requests in High-Level API. This is not controlled by the API version.
 
 ### Changed
 - Fixed searching values with multiple concurrent spaces.

--- a/src/Glpi/Api/HL/Controller/AbstractController.php
+++ b/src/Glpi/Api/HL/Controller/AbstractController.php
@@ -289,7 +289,7 @@ abstract class AbstractController
                 'type' => Doc\Schema::TYPE_STRING,
                 'readOnly' => true,
             ];
-        } else {
+        } elseif ($graphql_only) {
             $schema['x-graphql-only'] = true;
         }
 

--- a/src/Glpi/Api/HL/Controller/AbstractController.php
+++ b/src/Glpi/Api/HL/Controller/AbstractController.php
@@ -71,6 +71,7 @@ abstract class AbstractController
     public const ERROR_INVALID_PARAMETER = 'ERROR_INVALID_PARAMETER';
     public const ERROR_METHOD_NOT_ALLOWED = 'ERROR_METHOD_NOT_ALLOWED';
     public const ERROR_ALREADY_EXISTS = 'ERROR_ALREADY_EXISTS';
+    public const ERROR_PRECONDITION_FAILED = 'ERROR_PRECONDITION_FAILED';
 
     public const CRUD_ACTION_CREATE = 'create';
     public const CRUD_ACTION_READ = 'read';

--- a/src/Glpi/Api/HL/Controller/AbstractController.php
+++ b/src/Glpi/Api/HL/Controller/AbstractController.php
@@ -57,7 +57,7 @@ use Toolbox;
 
 /**
  * @phpstan-type AdditionalErrorMessage array{priority: string, message: string}
- * @phpstan-type ErrorResponseBody array{status: string, title: string, detail: string|null, additional_messages?: AdditionalErrorMessage[]}
+ * @phpstan-type ErrorResponseBody array{status: string, title: string, detail: array<mixed, mixed>|string|null, additional_messages?: AdditionalErrorMessage[]}
  * @phpstan-type InvalidParameterInfo array{name: string, reason?: string}
  */
 abstract class AbstractController
@@ -327,7 +327,7 @@ abstract class AbstractController
      * @param string $status
      * @phpstan-param self::ERROR_* $status
      * @param string $title
-     * @param string|array|null $detail
+     * @param string|array<mixed, mixed>|null $detail
      * @param AdditionalErrorMessage[] $additionalMessages
      * @return array
      * @phpstan-return ErrorResponseBody

--- a/src/Glpi/Api/HL/Controller/CoreController.php
+++ b/src/Glpi/Api/HL/Controller/CoreController.php
@@ -507,7 +507,7 @@ HTML;
             $response_headers['Access-Control-Allow-Headers'] = [
                 'Content-Type', 'Authorization', 'Origin', 'Accept',
                 'GLPI-API-Version', 'GLPI-Profile', 'GLPI-Entity', 'GLPI-Entity-Recursive',
-                'X-Debug-Mode',
+                'X-Debug-Mode', 'If-Modified-Since', 'If-Unmodified-Since',
             ];
             if (Environment::get()->shouldEnableExtraDevAndDebugTools()) {
                 $response_headers['Access-Control-Allow-Headers'][] = 'XDEBUG_TRIGGER';

--- a/src/Glpi/Api/HL/Doc/GetRoute.php
+++ b/src/Glpi/Api/HL/Doc/GetRoute.php
@@ -43,6 +43,18 @@ class GetRoute extends Route
     {
         parent::__construct(
             description: $description ?? 'Get an existing ' . $schema_name,
+            parameters: [
+                new Parameter(
+                    name: 'If-Modified-Since',
+                    schema: new Schema(type: Schema::TYPE_STRING, format: Schema::FORMAT_STRING_DATE_TIME),
+                    location: Parameter::LOCATION_HEADER,
+                ),
+                new Parameter(
+                    name: 'If-Unmodified-Since',
+                    schema: new Schema(type: Schema::TYPE_STRING, format: Schema::FORMAT_STRING_DATE_TIME),
+                    location: Parameter::LOCATION_HEADER,
+                ),
+            ],
             responses: [
                 new Response(schema: new SchemaReference($schema_name)),
             ]

--- a/src/Glpi/Api/HL/Doc/GetRoute.php
+++ b/src/Glpi/Api/HL/Doc/GetRoute.php
@@ -44,16 +44,8 @@ class GetRoute extends Route
         parent::__construct(
             description: $description ?? 'Get an existing ' . $schema_name,
             parameters: [
-                new Parameter(
-                    name: 'If-Modified-Since',
-                    schema: new Schema(type: Schema::TYPE_STRING, format: Schema::FORMAT_STRING_DATE_TIME),
-                    location: Parameter::LOCATION_HEADER,
-                ),
-                new Parameter(
-                    name: 'If-Unmodified-Since',
-                    schema: new Schema(type: Schema::TYPE_STRING, format: Schema::FORMAT_STRING_DATE_TIME),
-                    location: Parameter::LOCATION_HEADER,
-                ),
+                new ParameterReference('If-Modified-Since'),
+                new ParameterReference('If-Unmodified-Since'),
             ],
             responses: [
                 new Response(schema: new SchemaReference($schema_name)),

--- a/src/Glpi/Api/HL/Doc/UpdateRoute.php
+++ b/src/Glpi/Api/HL/Doc/UpdateRoute.php
@@ -49,6 +49,16 @@ class UpdateRoute extends Route
                     schema: new SchemaReference($schema_name),
                     location: Parameter::LOCATION_BODY,
                 ),
+                new Parameter(
+                    name: 'If-Modified-Since',
+                    schema: new Schema(type: Schema::TYPE_STRING, format: Schema::FORMAT_STRING_DATE_TIME),
+                    location: Parameter::LOCATION_HEADER,
+                ),
+                new Parameter(
+                    name: 'If-Unmodified-Since',
+                    schema: new Schema(type: Schema::TYPE_STRING, format: Schema::FORMAT_STRING_DATE_TIME),
+                    location: Parameter::LOCATION_HEADER,
+                ),
             ],
             responses: [
                 new Response(

--- a/src/Glpi/Api/HL/Doc/UpdateRoute.php
+++ b/src/Glpi/Api/HL/Doc/UpdateRoute.php
@@ -49,16 +49,8 @@ class UpdateRoute extends Route
                     schema: new SchemaReference($schema_name),
                     location: Parameter::LOCATION_BODY,
                 ),
-                new Parameter(
-                    name: 'If-Modified-Since',
-                    schema: new Schema(type: Schema::TYPE_STRING, format: Schema::FORMAT_STRING_DATE_TIME),
-                    location: Parameter::LOCATION_HEADER,
-                ),
-                new Parameter(
-                    name: 'If-Unmodified-Since',
-                    schema: new Schema(type: Schema::TYPE_STRING, format: Schema::FORMAT_STRING_DATE_TIME),
-                    location: Parameter::LOCATION_HEADER,
-                ),
+                new ParameterReference('If-Modified-Since'),
+                new ParameterReference('If-Unmodified-Since'),
             ],
             responses: [
                 new Response(

--- a/src/Glpi/Api/HL/GraphQL/Types.php
+++ b/src/Glpi/Api/HL/GraphQL/Types.php
@@ -50,6 +50,9 @@ class Types
 
     public static function load(string $type_name, string $api_version): Type
     {
+        if ($type_name === 'RFC3339DateTime') {
+            return DateTimeType::dateTime();
+        }
         if (!isset(self::$types[$type_name])) {
             $schema = Schemas::getInstance($api_version)->getSchema($type_name);
             if ($schema === null) {

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -264,6 +264,16 @@ EOT;
                     'type' => Doc\Schema::TYPE_STRING,
                 ],
             ],
+            'If-Modified-Since' => [
+                'name' => 'If-Modified-Since',
+                'in' => Doc\Parameter::LOCATION_HEADER,
+                'schema' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ],
+            'If-Unmodified-Since' => [
+                'name' => 'If-Unmodified-Since',
+                'in' => Doc\Parameter::LOCATION_HEADER,
+                'schema' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+            ],
         ];
     }
 

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -221,7 +221,7 @@ EOT;
     }
 
     /**
-     * @return array<string, array{name: string, in: string, description: string, schema: array<string, mixed>, example?: mixed, required?: bool}>
+     * @return array<string, array{name: string, in: string, description?: string, schema: array<string, mixed>, example?: mixed, required?: bool}>
      */
     public static function getParameterComponents(): array
     {

--- a/src/Glpi/Api/HL/ResourceAccessor.php
+++ b/src/Glpi/Api/HL/ResourceAccessor.php
@@ -274,8 +274,8 @@ final class ResourceAccessor
 
     /**
      * @param CommonDBTM $item
-     * @param array $headers
-     * @return array Array of failed preconditions. Empty array if all preconditions passed.
+     * @param array<string, string[]> $headers
+     * @return array<string, string> Array of failed preconditions. Empty array if all preconditions passed.
      * @throws \DateMalformedStringException
      */
     private static function validatePreconditions(CommonDBTM $item, array $headers): array
@@ -347,12 +347,14 @@ final class ResourceAccessor
         }
 
         $final_request = Router::getInstance()->getFinalRequest();
-        $precondition_failures = self::validatePreconditions($item, $final_request->getHeaders());
-        if (!empty($precondition_failures)) {
-            return new JSONResponse(
-                AbstractController::getErrorResponseBody(AbstractController::ERROR_PRECONDITION_FAILED, 'Precondition failed', $precondition_failures),
-                412
-            );
+        if ($final_request !== null) {
+            $precondition_failures = self::validatePreconditions($item, $final_request->getHeaders());
+            if ($precondition_failures !== []) {
+                return new JSONResponse(
+                    AbstractController::getErrorResponseBody(AbstractController::ERROR_PRECONDITION_FAILED, 'Precondition failed', $precondition_failures),
+                    412
+                );
+            }
         }
 
         $result = $item->update($input);
@@ -513,11 +515,12 @@ final class ResourceAccessor
 
         $result = $results['results'][0];
 
-        if (!empty($result['date_mod'])) {
+        $final_request = Router::getInstance()->getFinalRequest();
+        if ($final_request !== null && !empty($result['date_mod'])) {
             $item = self::getItemFromSchema($schema);
             $item->fields['date_mod'] = $result['date_mod'];
-            $precondition_failures = self::validatePreconditions($item, Router::getInstance()->getFinalRequest()->getHeaders());
-            if (!empty($precondition_failures)) {
+            $precondition_failures = self::validatePreconditions($item, $final_request->getHeaders());
+            if ($precondition_failures !== []) {
                 return new JSONResponse(
                     AbstractController::getErrorResponseBody(AbstractController::ERROR_PRECONDITION_FAILED, 'Precondition failed', $precondition_failures),
                     array_key_exists('If-Modified-Since', $precondition_failures) ? 304 : 412

--- a/src/Glpi/Api/HL/ResourceAccessor.php
+++ b/src/Glpi/Api/HL/ResourceAccessor.php
@@ -273,6 +273,42 @@ final class ResourceAccessor
     }
 
     /**
+     * @param CommonDBTM $item
+     * @param array $headers
+     * @return array Array of failed preconditions. Empty array if all preconditions passed.
+     * @throws \DateMalformedStringException
+     */
+    private static function validatePreconditions(CommonDBTM $item, array $headers): array
+    {
+        $failures = [];
+
+        $item_date_mod = $item->fields['date_mod'] ?? null;
+
+        if ($item_date_mod !== null && isset($headers['If-Unmodified-Since'])) {
+            $if_unmodified_since = $headers['If-Unmodified-Since'];
+            if (is_array($if_unmodified_since)) {
+                $if_unmodified_since = $if_unmodified_since[0];
+            }
+            $item_last_update_dt = new DateTime($item_date_mod);
+            $if_unmodified_since_dt = new DateTime($if_unmodified_since);
+            if ($item_last_update_dt > $if_unmodified_since_dt) {
+                $failures['If-Unmodified-Since'] = 'The item has been modified since the specified date';
+            }
+        } elseif ($item_date_mod !== null && isset($headers['If-Modified-Since'])) {
+            $if_modified_since = $headers['If-Modified-Since'];
+            if (is_array($if_modified_since)) {
+                $if_modified_since = $if_modified_since[0];
+            }
+            $item_last_update_dt = new DateTime($item_date_mod);
+            $if_modified_since_dt = new DateTime($if_modified_since);
+            if ($item_last_update_dt <= $if_modified_since_dt) {
+                $failures['If-Modified-Since'] = 'The item has not been modified since the specified date';
+            }
+        }
+        return $failures;
+    }
+
+    /**
      * Update an item of the given schema using the given request parameters.
      * @param array $schema The schema
      * @param array $request_attrs The request attributes
@@ -305,6 +341,20 @@ final class ResourceAccessor
         if (!$item->can($items_id, UPDATE, $input)) {
             return AbstractController::getAccessDeniedErrorResponse();
         }
+
+        if (!$item->getFromDB($items_id)) {
+            return AbstractController::getNotFoundErrorResponse();
+        }
+
+        $final_request = Router::getInstance()->getFinalRequest();
+        $precondition_failures = self::validatePreconditions($item, $final_request->getHeaders());
+        if (!empty($precondition_failures)) {
+            return new JSONResponse(
+                AbstractController::getErrorResponseBody(AbstractController::ERROR_PRECONDITION_FAILED, 'Precondition failed', $precondition_failures),
+                412
+            );
+        }
+
         $result = $item->update($input);
 
         if ($result === false) {
@@ -460,7 +510,22 @@ final class ResourceAccessor
         if (count($results['results']) === 0) {
             return AbstractController::getNotFoundErrorResponse();
         }
-        return new JSONResponse($results['results'][0]);
+
+        $result = $results['results'][0];
+
+        if (!empty($result['date_mod'])) {
+            $item = self::getItemFromSchema($schema);
+            $item->fields['date_mod'] = $result['date_mod'];
+            $precondition_failures = self::validatePreconditions($item, Router::getInstance()->getFinalRequest()->getHeaders());
+            if (!empty($precondition_failures)) {
+                return new JSONResponse(
+                    AbstractController::getErrorResponseBody(AbstractController::ERROR_PRECONDITION_FAILED, 'Precondition failed', $precondition_failures),
+                    array_key_exists('If-Modified-Since', $precondition_failures) ? 304 : 412
+                );
+            }
+        }
+
+        return new JSONResponse($result);
     }
 
     /**

--- a/tests/fixtures/hlapi/snapshots/2.0.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.0.0/paths.json
@@ -1733,6 +1733,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -1766,6 +1772,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -1843,6 +1855,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -1876,6 +1894,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -1953,6 +1977,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -1986,6 +2016,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2063,6 +2099,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2096,6 +2138,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2173,6 +2221,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2206,6 +2260,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2283,6 +2343,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2316,6 +2382,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2393,6 +2465,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2426,6 +2504,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2503,6 +2587,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2536,6 +2626,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2613,6 +2709,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2646,6 +2748,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2723,6 +2831,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2756,6 +2870,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2833,6 +2953,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2878,6 +3004,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2923,6 +3055,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2968,6 +3106,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3013,6 +3157,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3058,6 +3208,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3103,6 +3259,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3148,6 +3310,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3193,6 +3361,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3238,6 +3412,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3283,6 +3463,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3328,6 +3514,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3373,6 +3565,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3418,6 +3616,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3463,6 +3667,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3508,6 +3718,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3553,6 +3769,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3598,6 +3820,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3643,6 +3871,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3784,6 +4018,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3817,6 +4057,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3896,6 +4142,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cartridgeitems_id",
                     "description": "",
                     "in": "path",
@@ -3937,6 +4189,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "cartridgeitems_id",
@@ -4184,6 +4442,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4217,6 +4481,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4296,6 +4566,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "consumableitems_id",
                     "description": "",
                     "in": "path",
@@ -4337,6 +4613,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "consumableitems_id",
@@ -4584,6 +4866,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4617,6 +4905,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4790,6 +5084,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4823,6 +5123,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5019,6 +5325,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "rack_id",
                     "description": "",
                     "in": "path",
@@ -5060,6 +5372,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "rack_id",
@@ -5253,6 +5571,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5286,6 +5610,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5459,6 +5789,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5492,6 +5828,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5665,6 +6007,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5698,6 +6046,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5871,6 +6225,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5904,6 +6264,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -6077,6 +6443,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -6110,6 +6482,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -6306,6 +6684,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "software_id",
                     "description": "",
                     "in": "path",
@@ -6347,6 +6731,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "software_id",
@@ -6485,792 +6875,6 @@
                 }
             },
             "parameters": [],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Model": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Model/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Type": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Type/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
             "security": [
                 {
                     "oauth": [
@@ -9117,6 +8721,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9148,6 +8758,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9224,6 +8840,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9255,6 +8877,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9331,6 +8959,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9362,6 +8996,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9438,6 +9078,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9469,6 +9115,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9545,6 +9197,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9576,6 +9234,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9652,6 +9316,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9683,6 +9353,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9759,6 +9435,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9790,6 +9472,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9866,6 +9554,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9897,6 +9591,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9973,6 +9673,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10004,6 +9710,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10080,6 +9792,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10111,6 +9829,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10187,6 +9911,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10218,6 +9948,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10294,6 +10030,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10325,6 +10067,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10401,6 +10149,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10432,6 +10186,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10508,6 +10268,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10539,6 +10305,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10615,6 +10387,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10646,6 +10424,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10722,6 +10506,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10753,6 +10543,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10829,6 +10625,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10860,6 +10662,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10936,6 +10744,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10967,6 +10781,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12213,6 +12033,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12256,6 +12082,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12301,6 +12133,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12344,6 +12182,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12389,6 +12233,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12432,6 +12282,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12477,6 +12333,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12520,6 +12382,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12565,6 +12433,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12608,6 +12482,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12653,6 +12533,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12696,6 +12582,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12741,6 +12633,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12784,6 +12682,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12829,6 +12733,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12872,6 +12782,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12917,6 +12833,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12960,6 +12882,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -25002,6 +24930,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -25035,6 +24969,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -25112,6 +25052,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -25145,6 +25091,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -25222,6 +25174,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -25255,6 +25213,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -26913,6 +26877,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -26954,6 +26924,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27053,6 +27029,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27094,6 +27076,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27193,6 +27181,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27234,6 +27228,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27333,6 +27333,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27374,6 +27380,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27473,6 +27485,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27514,6 +27532,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27613,6 +27637,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27654,6 +27684,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27753,6 +27789,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27794,6 +27836,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27893,6 +27941,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27934,6 +27988,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -28033,6 +28093,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -28074,6 +28140,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -28173,6 +28245,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -28214,6 +28292,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -28313,6 +28397,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -28354,6 +28444,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -28453,6 +28549,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -28494,6 +28596,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -28593,6 +28701,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -28634,6 +28748,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -28733,6 +28853,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -28774,6 +28900,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -29684,6 +29816,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -29717,6 +29855,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -29890,6 +30034,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -29923,6 +30073,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30096,6 +30252,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30129,6 +30291,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30579,7 +30747,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -30708,6 +30883,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -30750,7 +30931,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -30801,6 +30989,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -30832,6 +31026,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -30908,6 +31108,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "username",
                     "description": "",
                     "in": "path",
@@ -30939,6 +31145,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "username",
                     "description": "",
@@ -31275,6 +31487,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -31306,6 +31524,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -31382,6 +31606,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -31413,6 +31643,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -31489,6 +31725,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -31520,6 +31762,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -32792,6 +33040,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -32823,6 +33077,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -32899,6 +33159,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -32930,6 +33196,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33006,6 +33278,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33037,6 +33315,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33113,6 +33397,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33144,6 +33434,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33220,6 +33516,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33251,6 +33553,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33327,6 +33635,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33358,6 +33672,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33434,6 +33754,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33465,6 +33791,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33541,6 +33873,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33572,6 +33910,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33648,6 +33992,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33679,6 +34029,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33755,6 +34111,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33786,6 +34148,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33862,6 +34230,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33893,6 +34267,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -34065,6 +34445,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -34096,6 +34482,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -34268,6 +34660,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -34299,6 +34697,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -34971,6 +35375,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -35004,6 +35414,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -35081,6 +35497,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -35114,6 +35536,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -35191,6 +35619,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -35224,6 +35658,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -35301,6 +35741,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -35334,6 +35780,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -39849,6 +40301,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -39890,6 +40348,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -39966,6 +40430,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40007,6 +40477,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40083,6 +40559,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40124,6 +40606,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40200,6 +40688,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40241,6 +40735,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40317,6 +40817,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40358,6 +40864,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40434,6 +40946,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40475,6 +40993,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40551,6 +41075,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40592,6 +41122,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40668,6 +41204,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40709,6 +41251,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40785,6 +41333,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40826,6 +41380,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40902,6 +41462,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40943,6 +41509,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -41019,6 +41591,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -41060,6 +41638,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -41730,6 +42314,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -41781,6 +42371,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -41880,6 +42476,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -41931,6 +42533,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -42030,6 +42638,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42081,6 +42695,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -42180,6 +42800,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42231,6 +42857,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -42330,6 +42962,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42381,6 +43019,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -42480,6 +43124,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42531,6 +43181,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -42630,6 +43286,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42681,6 +43343,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -42780,6 +43448,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42831,6 +43505,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -42930,6 +43610,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42981,6 +43667,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -43080,6 +43772,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -43131,6 +43829,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -43230,6 +43934,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -43281,6 +43991,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -43963,6 +44679,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -44014,6 +44736,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -44113,6 +44841,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -44164,6 +44898,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -44263,6 +45003,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -44314,6 +45060,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -44413,6 +45165,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -44464,6 +45222,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -44563,6 +45327,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -44614,6 +45384,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -44713,6 +45489,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -44764,6 +45546,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -44863,6 +45651,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -44914,6 +45708,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -45013,6 +45813,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -45064,6 +45870,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -45163,6 +45975,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -45214,6 +46032,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -45313,6 +46137,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -45364,6 +46194,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -45463,6 +46299,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -45514,6 +46356,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -46992,6 +47840,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -47023,6 +47877,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",

--- a/tests/fixtures/hlapi/snapshots/2.1.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.1.0/paths.json
@@ -1733,6 +1733,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -1766,6 +1772,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -1843,6 +1855,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -1876,6 +1894,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -1953,6 +1977,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -1986,6 +2016,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2063,6 +2099,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2096,6 +2138,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2173,6 +2221,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2206,6 +2260,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2283,6 +2343,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2316,6 +2382,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2393,6 +2465,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2426,6 +2504,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2503,6 +2587,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2536,6 +2626,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2613,6 +2709,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2646,6 +2748,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2723,6 +2831,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2756,6 +2870,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2833,6 +2953,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2878,6 +3004,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2923,6 +3055,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2968,6 +3106,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3013,6 +3157,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3058,6 +3208,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3103,6 +3259,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3148,6 +3310,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3193,6 +3361,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3238,6 +3412,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3283,6 +3463,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3328,6 +3514,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3373,6 +3565,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3418,6 +3616,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3463,6 +3667,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3508,6 +3718,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3553,6 +3769,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3598,6 +3820,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3643,6 +3871,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3784,6 +4018,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3817,6 +4057,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3896,6 +4142,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cartridgeitems_id",
                     "description": "",
                     "in": "path",
@@ -3937,6 +4189,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "cartridgeitems_id",
@@ -4184,6 +4442,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4217,6 +4481,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4296,6 +4566,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "consumableitems_id",
                     "description": "",
                     "in": "path",
@@ -4337,6 +4613,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "consumableitems_id",
@@ -4584,6 +4866,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4617,6 +4905,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4790,6 +5084,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4823,6 +5123,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5019,6 +5325,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "rack_id",
                     "description": "",
                     "in": "path",
@@ -5060,6 +5372,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "rack_id",
@@ -5253,6 +5571,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5286,6 +5610,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5459,6 +5789,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5492,6 +5828,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5665,6 +6007,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5698,6 +6046,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5871,6 +6225,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5904,6 +6264,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -6077,6 +6443,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -6110,6 +6482,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -6306,6 +6684,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "software_id",
                     "description": "",
                     "in": "path",
@@ -6347,6 +6731,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "software_id",
@@ -6485,792 +6875,6 @@
                 }
             },
             "parameters": [],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Model": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Model/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Type": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Type/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
             "security": [
                 {
                     "oauth": [
@@ -9117,6 +8721,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9148,6 +8758,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9224,6 +8840,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9255,6 +8877,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9331,6 +8959,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9362,6 +8996,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9438,6 +9078,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9469,6 +9115,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9545,6 +9197,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9576,6 +9234,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9652,6 +9316,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9683,6 +9353,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9759,6 +9435,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9790,6 +9472,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9866,6 +9554,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -9897,6 +9591,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -9973,6 +9673,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10004,6 +9710,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10080,6 +9792,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10111,6 +9829,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10187,6 +9911,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10218,6 +9948,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10294,6 +10030,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10325,6 +10067,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10401,6 +10149,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10432,6 +10186,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10508,6 +10268,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10539,6 +10305,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10615,6 +10387,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10646,6 +10424,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10722,6 +10506,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10753,6 +10543,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10829,6 +10625,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10860,6 +10662,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -10936,6 +10744,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -10967,6 +10781,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12213,6 +12033,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12256,6 +12082,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12301,6 +12133,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12344,6 +12182,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12389,6 +12233,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12432,6 +12282,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12477,6 +12333,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12520,6 +12382,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12565,6 +12433,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12608,6 +12482,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12653,6 +12533,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12696,6 +12582,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12741,6 +12633,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12784,6 +12682,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12829,6 +12733,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12872,6 +12782,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -12917,6 +12833,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -12960,6 +12882,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -25002,6 +24930,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -25035,6 +24969,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -25112,6 +25052,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -25145,6 +25091,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -25222,6 +25174,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -25255,6 +25213,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -26913,6 +26877,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -26954,6 +26924,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27053,6 +27029,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27094,6 +27076,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27193,6 +27181,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27234,6 +27228,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27333,6 +27333,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27374,6 +27380,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27473,6 +27485,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27514,6 +27532,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27613,6 +27637,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27654,6 +27684,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27753,6 +27789,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27794,6 +27836,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -27893,6 +27941,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -27934,6 +27988,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -28033,6 +28093,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -28074,6 +28140,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -28173,6 +28245,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -28214,6 +28292,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -28313,6 +28397,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -28354,6 +28444,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -28453,6 +28549,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -28494,6 +28596,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -28593,6 +28701,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -28634,6 +28748,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -28733,6 +28853,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -28774,6 +28900,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -29684,6 +29816,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -29717,6 +29855,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -29890,6 +30034,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -29923,6 +30073,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30096,6 +30252,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30129,6 +30291,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30579,7 +30747,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -30708,6 +30883,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -30750,7 +30931,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -30801,6 +30989,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -30832,6 +31026,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -30908,6 +31108,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "username",
                     "description": "",
                     "in": "path",
@@ -30939,6 +31145,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "username",
                     "description": "",
@@ -31275,6 +31487,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -31306,6 +31524,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -31382,6 +31606,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -31413,6 +31643,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -31489,6 +31725,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -31520,6 +31762,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -31596,6 +31844,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -31627,6 +31881,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -31679,7 +31939,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -31700,7 +31967,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -31744,6 +32018,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "username",
                     "description": "",
                     "in": "path",
@@ -31775,6 +32055,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "username",
                     "description": "",
@@ -33025,6 +33311,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33056,6 +33348,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33132,6 +33430,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33163,6 +33467,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33239,6 +33549,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33270,6 +33586,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33346,6 +33668,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33377,6 +33705,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33453,6 +33787,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33484,6 +33824,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33560,6 +33906,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33591,6 +33943,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33667,6 +34025,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33698,6 +34062,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33774,6 +34144,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33805,6 +34181,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33881,6 +34263,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -33912,6 +34300,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -33988,6 +34382,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -34019,6 +34419,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -34095,6 +34501,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -34126,6 +34538,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -34298,6 +34716,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -34329,6 +34753,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -34501,6 +34931,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -34532,6 +34968,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35204,6 +35646,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -35237,6 +35685,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -35314,6 +35768,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -35347,6 +35807,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -35424,6 +35890,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -35457,6 +35929,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -35534,6 +36012,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -35567,6 +36051,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -40082,6 +40572,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40123,6 +40619,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40199,6 +40701,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40240,6 +40748,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40316,6 +40830,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40357,6 +40877,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40433,6 +40959,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40474,6 +41006,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40550,6 +41088,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40591,6 +41135,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40667,6 +41217,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40708,6 +41264,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40784,6 +41346,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40825,6 +41393,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40901,6 +41475,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40942,6 +41522,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -41018,6 +41604,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -41059,6 +41651,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -41135,6 +41733,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -41176,6 +41780,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -41252,6 +41862,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -41293,6 +41909,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -41963,6 +42585,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42014,6 +42642,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -42113,6 +42747,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42164,6 +42804,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -42263,6 +42909,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42314,6 +42966,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -42413,6 +43071,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42464,6 +43128,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -42563,6 +43233,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42614,6 +43290,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -42713,6 +43395,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42764,6 +43452,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -42863,6 +43557,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42914,6 +43614,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -43013,6 +43719,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -43064,6 +43776,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -43163,6 +43881,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -43214,6 +43938,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -43313,6 +44043,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -43364,6 +44100,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -43463,6 +44205,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -43514,6 +44262,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -44196,6 +44950,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -44247,6 +45007,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -44346,6 +45112,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -44397,6 +45169,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -44496,6 +45274,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -44547,6 +45331,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -44646,6 +45436,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -44697,6 +45493,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -44796,6 +45598,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -44847,6 +45655,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -44946,6 +45760,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -44997,6 +45817,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -45096,6 +45922,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -45147,6 +45979,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -45246,6 +46084,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -45297,6 +46141,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -45396,6 +46246,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -45447,6 +46303,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -45546,6 +46408,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -45597,6 +46465,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -45696,6 +46570,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -45747,6 +46627,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -47321,6 +48207,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -47352,6 +48244,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -47428,6 +48326,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -47459,6 +48363,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -47715,6 +48625,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -47746,6 +48662,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -47822,6 +48744,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "context",
                     "description": "",
                     "in": "path",
@@ -47882,6 +48810,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "context",
                     "description": "",

--- a/tests/fixtures/hlapi/snapshots/2.2.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.2.0/paths.json
@@ -1748,6 +1748,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -1781,6 +1787,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -1858,6 +1870,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -1891,6 +1909,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -1968,6 +1992,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2001,6 +2031,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2078,6 +2114,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2111,6 +2153,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2188,6 +2236,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2221,6 +2275,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2298,6 +2358,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2331,6 +2397,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2408,6 +2480,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2441,6 +2519,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2518,6 +2602,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2551,6 +2641,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2628,6 +2724,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2661,6 +2763,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2738,6 +2846,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2771,6 +2885,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2848,6 +2968,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2934,6 +3060,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3011,6 +3143,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3097,6 +3235,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3174,6 +3318,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3260,6 +3410,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3337,6 +3493,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3423,6 +3585,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3500,6 +3668,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3586,6 +3760,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3663,6 +3843,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3749,6 +3935,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3826,6 +4018,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3912,6 +4110,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3989,6 +4193,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4075,6 +4285,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4152,6 +4368,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4238,6 +4460,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4315,6 +4543,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4401,6 +4635,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4478,6 +4718,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4564,6 +4810,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4641,6 +4893,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4727,6 +4985,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4804,6 +5068,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4890,6 +5160,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4967,6 +5243,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5053,6 +5335,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5130,6 +5418,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5216,6 +5510,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5293,6 +5593,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5379,6 +5685,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5456,6 +5768,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5542,6 +5860,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5619,6 +5943,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5705,6 +6035,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5782,6 +6118,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5868,6 +6210,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -6041,6 +6389,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -6074,6 +6428,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -6153,6 +6513,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cartridgeitems_id",
                     "description": "",
                     "in": "path",
@@ -6194,6 +6560,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "cartridgeitems_id",
@@ -6441,6 +6813,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -6474,6 +6852,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -6553,6 +6937,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "consumableitems_id",
                     "description": "",
                     "in": "path",
@@ -6594,6 +6984,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "consumableitems_id",
@@ -6841,6 +7237,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -6874,6 +7276,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -7047,6 +7455,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -7080,6 +7494,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -7276,6 +7696,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "rack_id",
                     "description": "",
                     "in": "path",
@@ -7317,6 +7743,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "rack_id",
@@ -7510,6 +7942,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -7543,6 +7981,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -7716,6 +8160,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -7749,6 +8199,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -7922,6 +8378,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -7955,6 +8417,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -8128,6 +8596,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -8161,6 +8635,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -8334,6 +8814,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -8367,6 +8853,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -8563,6 +9055,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "software_id",
                     "description": "",
                     "in": "path",
@@ -8604,6 +9102,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "software_id",
@@ -8770,7 +9274,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -8791,7 +9302,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9644,7 +10162,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9665,7 +10190,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9718,7 +10250,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9739,7 +10278,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9792,7 +10338,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9813,7 +10366,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9866,7 +10426,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9887,7 +10454,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9940,7 +10514,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9961,7 +10542,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10014,7 +10602,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10035,7 +10630,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10088,7 +10690,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10109,7 +10718,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10162,7 +10778,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10183,7 +10806,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10236,7 +10866,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10257,7 +10894,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10310,7 +10954,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10331,7 +10982,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10436,792 +11094,6 @@
                 }
             },
             "parameters": [],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Model": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Model/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Type": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Type/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
             "security": [
                 {
                     "oauth": [
@@ -13068,6 +12940,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -13099,6 +12977,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -13175,6 +13059,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -13206,6 +13096,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -13282,6 +13178,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -13313,6 +13215,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -13389,6 +13297,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -13420,6 +13334,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -13496,6 +13416,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -13527,6 +13453,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -13603,6 +13535,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -13634,6 +13572,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -13710,6 +13654,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -13741,6 +13691,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -13817,6 +13773,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -13848,6 +13810,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -13924,6 +13892,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -13955,6 +13929,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -14031,6 +14011,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -14062,6 +14048,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -14138,6 +14130,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -14169,6 +14167,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -14245,6 +14249,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -14276,6 +14286,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -14352,6 +14368,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -14383,6 +14405,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -14459,6 +14487,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -14490,6 +14524,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -14566,6 +14606,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -14597,6 +14643,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -14673,6 +14725,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -14704,6 +14762,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -14780,6 +14844,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -14811,6 +14881,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -14887,6 +14963,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -14918,6 +15000,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -16164,6 +16252,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -16207,6 +16301,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -16252,6 +16352,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -16295,6 +16401,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -16340,6 +16452,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -16383,6 +16501,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -16428,6 +16552,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -16471,6 +16601,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -16516,6 +16652,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -16559,6 +16701,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -16604,6 +16752,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -16647,6 +16801,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -16692,6 +16852,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -16735,6 +16901,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -16780,6 +16952,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -16823,6 +17001,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -16868,6 +17052,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -16911,6 +17101,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -28953,6 +29149,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -28986,6 +29188,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -29063,6 +29271,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -29096,6 +29310,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -29173,6 +29393,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -29206,6 +29432,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30864,6 +31096,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -30905,6 +31143,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -31004,6 +31248,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -31045,6 +31295,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -31144,6 +31400,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -31185,6 +31447,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -31284,6 +31552,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -31325,6 +31599,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -31424,6 +31704,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -31465,6 +31751,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -31564,6 +31856,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -31605,6 +31903,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -31704,6 +32008,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -31745,6 +32055,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -31844,6 +32160,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -31885,6 +32207,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -31984,6 +32312,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -32025,6 +32359,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -32124,6 +32464,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -32165,6 +32511,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -32264,6 +32616,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -32305,6 +32663,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -32404,6 +32768,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -32445,6 +32815,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -32544,6 +32920,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -32585,6 +32967,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -32684,6 +33072,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -32725,6 +33119,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -33635,6 +34035,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -33668,6 +34074,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -33841,6 +34253,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -33874,6 +34292,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -34047,6 +34471,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -34080,6 +34510,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -34530,7 +34966,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -34659,6 +35102,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -34701,7 +35150,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -34752,6 +35208,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -34783,6 +35245,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -34859,6 +35327,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "username",
                     "description": "",
                     "in": "path",
@@ -34890,6 +35364,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "username",
                     "description": "",
@@ -35226,6 +35706,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -35257,6 +35743,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35333,6 +35825,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -35364,6 +35862,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35440,6 +35944,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -35471,6 +35981,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35547,6 +36063,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -35578,6 +36100,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35630,7 +36158,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -35651,7 +36186,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -35695,6 +36237,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "username",
                     "description": "",
                     "in": "path",
@@ -35726,6 +36274,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "username",
                     "description": "",
@@ -35833,7 +36387,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -36156,6 +36717,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -36187,6 +36754,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -36263,6 +36836,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -36294,6 +36873,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -36369,6 +36954,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -37728,6 +38319,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -37759,6 +38356,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -37835,6 +38438,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -37866,6 +38475,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -37942,6 +38557,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -37973,6 +38594,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -38049,6 +38676,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38080,6 +38713,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -38156,6 +38795,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38187,6 +38832,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -38263,6 +38914,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38294,6 +38951,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -38370,6 +39033,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38401,6 +39070,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -38477,6 +39152,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38508,6 +39189,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -38584,6 +39271,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38615,6 +39308,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -38691,6 +39390,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38722,6 +39427,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -38798,6 +39509,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38829,6 +39546,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -38905,6 +39628,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38936,6 +39665,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -39108,6 +39843,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -39139,6 +39880,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -39311,6 +40058,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -39342,6 +40095,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -42702,6 +43461,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -42735,6 +43500,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -42812,6 +43583,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -42845,6 +43622,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -42922,6 +43705,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -42955,6 +43744,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -43032,6 +43827,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -43065,6 +43866,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -43142,6 +43949,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -43175,6 +43988,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -43252,6 +44071,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -43285,6 +44110,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -43362,6 +44193,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -43395,6 +44232,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -43472,6 +44315,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -43505,6 +44354,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -43582,6 +44437,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -43615,6 +44476,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -43692,6 +44559,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -43725,6 +44598,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -43802,6 +44681,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -43835,6 +44720,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -43912,6 +44803,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -43945,6 +44842,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -44022,6 +44925,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -44055,6 +44964,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -44132,6 +45047,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -44165,6 +45086,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -44242,6 +45169,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -44275,6 +45208,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -44352,6 +45291,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -44385,6 +45330,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -44462,6 +45413,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -44495,6 +45452,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -44572,6 +45535,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -44605,6 +45574,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -44682,6 +45657,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -44715,6 +45696,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -44792,6 +45779,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -44825,6 +45818,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -44902,6 +45901,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -44935,6 +45940,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -45012,6 +46023,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -45045,6 +46062,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -45122,6 +46145,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -45155,6 +46184,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -45232,6 +46267,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -45265,6 +46306,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -45342,6 +46389,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -45375,6 +46428,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -45452,6 +46511,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -45485,6 +46550,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -45562,6 +46633,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -45595,6 +46672,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -45672,6 +46755,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -45705,6 +46794,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -45782,6 +46877,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -45815,6 +46916,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -45892,6 +46999,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -45925,6 +47038,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -46002,6 +47121,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -46035,6 +47160,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -46112,6 +47243,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -46145,6 +47282,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -50660,6 +51803,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -50701,6 +51850,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -50777,6 +51932,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -50818,6 +51979,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -50894,6 +52061,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -50935,6 +52108,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -51011,6 +52190,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -51052,6 +52237,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -51128,6 +52319,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -51169,6 +52366,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -51245,6 +52448,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -51286,6 +52495,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -51362,6 +52577,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -51403,6 +52624,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -51479,6 +52706,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -51520,6 +52753,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -51596,6 +52835,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -51637,6 +52882,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -51713,6 +52964,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -51754,6 +53011,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -51830,6 +53093,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -51871,6 +53140,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -52541,6 +53816,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -52592,6 +53873,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -52691,6 +53978,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -52742,6 +54035,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -52841,6 +54140,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -52892,6 +54197,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -52991,6 +54302,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -53042,6 +54359,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -53141,6 +54464,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -53192,6 +54521,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -53291,6 +54626,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -53342,6 +54683,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -53441,6 +54788,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -53492,6 +54845,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -53591,6 +54950,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -53642,6 +55007,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -53741,6 +55112,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -53792,6 +55169,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -53891,6 +55274,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -53942,6 +55331,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -54041,6 +55436,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -54092,6 +55493,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -54774,6 +56181,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -54825,6 +56238,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -54924,6 +56343,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -54975,6 +56400,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -55074,6 +56505,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -55125,6 +56562,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -55224,6 +56667,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -55275,6 +56724,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -55374,6 +56829,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -55425,6 +56886,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -55524,6 +56991,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -55575,6 +57048,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -55674,6 +57153,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -55725,6 +57210,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -55824,6 +57315,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -55875,6 +57372,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -55974,6 +57477,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -56025,6 +57534,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -56124,6 +57639,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -56175,6 +57696,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -56274,6 +57801,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -56325,6 +57858,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -57899,6 +59438,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -57930,6 +59475,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -58006,6 +59557,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -58037,6 +59594,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -58293,6 +59856,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -58324,6 +59893,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -58400,6 +59975,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "context",
                     "description": "",
                     "in": "path",
@@ -58460,6 +60041,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "context",
                     "description": "",
@@ -62167,6 +63754,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -62208,6 +63801,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -62294,6 +63893,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -62335,6 +63940,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -62421,6 +64032,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -62462,6 +64079,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -62548,6 +64171,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -62589,6 +64218,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -62675,6 +64310,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -62716,6 +64357,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -62802,6 +64449,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -62843,6 +64496,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -62929,6 +64588,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -62970,6 +64635,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -63056,6 +64727,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -63097,6 +64774,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -63183,6 +64866,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -63224,6 +64913,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -63310,6 +65005,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -63351,6 +65052,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -63437,6 +65144,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -63478,6 +65191,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -63564,6 +65283,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -63605,6 +65330,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -63691,6 +65422,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -63732,6 +65469,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -63818,6 +65561,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -63859,6 +65608,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -63945,6 +65700,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -63986,6 +65747,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -64072,6 +65839,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -64113,6 +65886,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -64199,6 +65978,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -64240,6 +66025,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -64326,6 +66117,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -64367,6 +66164,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -64453,6 +66256,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -64494,6 +66303,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -64580,6 +66395,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -64621,6 +66442,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -64707,6 +66534,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -64748,6 +66581,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -64834,6 +66673,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -64875,6 +66720,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -64961,6 +66812,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -65002,6 +66859,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -65088,6 +66951,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -65129,6 +66998,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -65215,6 +67090,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -65256,6 +67137,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -65342,6 +67229,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -65383,6 +67276,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -65469,6 +67368,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -65510,6 +67415,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -65596,6 +67507,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -65637,6 +67554,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -65723,6 +67646,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -65764,6 +67693,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -65850,6 +67785,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -65891,6 +67832,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -66126,6 +68073,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -66170,6 +68123,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -66388,6 +68347,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -66432,6 +68397,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -66683,6 +68654,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -66738,6 +68715,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -66925,6 +68908,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -67058,6 +69047,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [

--- a/tests/fixtures/hlapi/snapshots/2.3.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.3.0/paths.json
@@ -1775,6 +1775,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -1808,6 +1814,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -1885,6 +1897,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -1918,6 +1936,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -1995,6 +2019,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2028,6 +2058,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2105,6 +2141,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2138,6 +2180,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2215,6 +2263,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2248,6 +2302,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2325,6 +2385,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2358,6 +2424,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2435,6 +2507,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2468,6 +2546,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2545,6 +2629,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2578,6 +2668,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2655,6 +2751,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2688,6 +2790,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2765,6 +2873,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2798,6 +2912,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2875,6 +2995,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2961,6 +3087,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3038,6 +3170,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3124,6 +3262,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3201,6 +3345,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3287,6 +3437,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3364,6 +3520,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3450,6 +3612,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3527,6 +3695,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3613,6 +3787,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3690,6 +3870,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3776,6 +3962,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3853,6 +4045,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3939,6 +4137,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4016,6 +4220,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4102,6 +4312,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4179,6 +4395,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4265,6 +4487,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4342,6 +4570,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4428,6 +4662,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4505,6 +4745,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4591,6 +4837,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4668,6 +4920,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4754,6 +5012,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4831,6 +5095,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4917,6 +5187,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4994,6 +5270,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5080,6 +5362,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5157,6 +5445,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5243,6 +5537,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5320,6 +5620,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5406,6 +5712,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5483,6 +5795,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5569,6 +5887,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5646,6 +5970,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5732,6 +6062,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5809,6 +6145,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5895,6 +6237,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -6068,6 +6416,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -6101,6 +6455,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -6180,6 +6540,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cartridgeitems_id",
                     "description": "",
                     "in": "path",
@@ -6221,6 +6587,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "cartridgeitems_id",
@@ -6468,6 +6840,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -6501,6 +6879,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -6580,6 +6964,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "consumableitems_id",
                     "description": "",
                     "in": "path",
@@ -6621,6 +7011,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "consumableitems_id",
@@ -6868,6 +7264,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -6901,6 +7303,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -7074,6 +7482,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -7107,6 +7521,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -7303,6 +7723,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "rack_id",
                     "description": "",
                     "in": "path",
@@ -7344,6 +7770,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "rack_id",
@@ -7537,6 +7969,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -7570,6 +8008,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -7743,6 +8187,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -7776,6 +8226,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -7949,6 +8405,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -7982,6 +8444,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -8155,6 +8623,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -8188,6 +8662,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -8361,6 +8841,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -8394,6 +8880,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -8590,6 +9082,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "software_id",
                     "description": "",
                     "in": "path",
@@ -8631,6 +9129,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "software_id",
@@ -8797,7 +9301,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -8818,7 +9329,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9671,7 +10189,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9692,7 +10217,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9745,7 +10277,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9766,7 +10305,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9819,7 +10365,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9840,7 +10393,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9893,7 +10453,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9914,7 +10481,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9967,7 +10541,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9988,7 +10569,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10041,7 +10629,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10062,7 +10657,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10115,7 +10717,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10136,7 +10745,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10189,7 +10805,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10210,7 +10833,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10263,7 +10893,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10284,7 +10921,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10337,7 +10981,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10358,7 +11009,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11211,7 +11869,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11232,7 +11897,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11285,7 +11957,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11306,7 +11985,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11359,7 +12045,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11380,7 +12073,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11433,7 +12133,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11454,7 +12161,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11507,7 +12221,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11528,7 +12249,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11581,7 +12309,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11602,7 +12337,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11655,7 +12397,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11676,7 +12425,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11729,7 +12485,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11750,7 +12513,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11803,7 +12573,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11824,7 +12601,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11877,7 +12661,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11898,7 +12689,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -12751,7 +13549,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -12772,7 +13577,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -12825,7 +13637,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -12846,7 +13665,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -12899,7 +13725,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -12920,7 +13753,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -12973,7 +13813,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -12994,7 +13841,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -13047,7 +13901,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -13068,7 +13929,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -13121,7 +13989,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -13142,7 +14017,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -13195,7 +14077,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -13216,7 +14105,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -13269,7 +14165,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -13290,7 +14193,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -13343,7 +14253,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -13364,7 +14281,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -13417,7 +14341,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -13438,7 +14369,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14291,7 +15229,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14312,7 +15257,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14365,7 +15317,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14386,7 +15345,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14439,7 +15405,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14460,7 +15433,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14513,7 +15493,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14534,7 +15521,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14587,7 +15581,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14608,7 +15609,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14661,7 +15669,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14682,7 +15697,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14735,7 +15757,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14756,7 +15785,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14809,7 +15845,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14830,7 +15873,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14883,7 +15933,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14904,7 +15961,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14957,7 +16021,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14978,7 +16049,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -15831,7 +16909,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -15852,7 +16937,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -15905,7 +16997,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -15926,7 +17025,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -15979,7 +17085,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16000,7 +17113,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16053,7 +17173,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16074,7 +17201,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16127,7 +17261,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16148,7 +17289,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16201,7 +17349,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16222,7 +17377,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16275,7 +17437,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16296,7 +17465,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16349,7 +17525,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16370,7 +17553,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16423,7 +17613,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16444,7 +17641,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16497,7 +17701,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16518,7 +17729,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -17012,7 +18230,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17056,7 +18281,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17100,7 +18332,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17144,7 +18383,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17188,7 +18434,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17232,7 +18485,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17276,7 +18536,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17320,7 +18587,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17364,7 +18638,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17408,7 +18689,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -18653,6 +19941,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -18697,6 +19991,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -18796,6 +20096,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -18840,6 +20146,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -18939,6 +20251,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -18983,6 +20301,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -19082,6 +20406,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -19126,6 +20456,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -19225,6 +20561,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -19269,6 +20611,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -19368,6 +20716,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -19412,6 +20766,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -19511,6 +20871,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -19555,6 +20921,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -19654,6 +21026,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -19698,6 +21076,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -19797,6 +21181,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -19841,6 +21231,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -19940,6 +21336,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -19984,6 +21386,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -20916,6 +22324,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -20960,6 +22374,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -21059,6 +22479,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -21103,6 +22529,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -21202,6 +22634,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -21246,6 +22684,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -21345,6 +22789,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -21389,6 +22839,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -21488,6 +22944,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -21532,6 +22994,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -21631,6 +23099,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -21675,6 +23149,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -21774,6 +23254,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -21818,6 +23304,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -22988,6 +24480,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -23032,6 +24530,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -23131,6 +24635,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -23175,6 +24685,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -23274,6 +24790,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -23318,6 +24840,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -23417,6 +24945,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -23461,6 +24995,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -23560,6 +25100,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -23604,6 +25150,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -23703,6 +25255,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -23747,6 +25305,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -23846,6 +25410,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -23890,6 +25460,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -23989,6 +25565,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -24033,6 +25615,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -24132,6 +25720,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -24176,6 +25770,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -24870,6 +26470,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -24914,6 +26520,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -25013,6 +26625,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -25057,6 +26675,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -25156,6 +26780,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -25200,6 +26830,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -25299,6 +26935,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -25343,6 +26985,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -25442,6 +27090,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -25486,6 +27140,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -26775,6 +28435,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -26819,6 +28485,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -26918,6 +28590,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -26962,6 +28640,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -27061,6 +28745,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -27105,6 +28795,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -27204,6 +28900,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -27248,6 +28950,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -27347,6 +29055,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -27391,6 +29105,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -27490,6 +29210,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -27534,6 +29260,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -27633,6 +29365,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -27677,6 +29415,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -27776,6 +29520,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -27820,6 +29570,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -27919,6 +29675,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -27963,6 +29725,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -28062,6 +29830,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -28106,6 +29880,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -29871,6 +31651,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -29915,6 +31701,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30014,6 +31806,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30058,6 +31856,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30157,6 +31961,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30201,6 +32011,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30300,6 +32116,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30344,6 +32166,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30443,6 +32271,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30487,6 +32321,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30586,6 +32426,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30630,6 +32476,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30729,6 +32581,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30773,6 +32631,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30872,6 +32736,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30916,6 +32786,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -31015,6 +32891,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -31059,6 +32941,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -31158,6 +33046,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -31202,6 +33096,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -31301,6 +33201,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -31345,6 +33251,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -31444,6 +33356,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -31488,6 +33406,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -31587,6 +33511,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -31631,6 +33561,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -31730,6 +33666,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -31774,6 +33716,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -31903,792 +33851,6 @@
                 }
             },
             "parameters": [],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Model": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Model/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Type": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/{itemtype}Type/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_{itemtype}Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "itemtype",
-                    "description": "Asset type",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string",
-                        "format": "string",
-                        "pattern": ""
-                    }
-                },
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
             "security": [
                 {
                     "oauth": [
@@ -34535,6 +35697,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -34566,6 +35734,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -34642,6 +35816,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -34673,6 +35853,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -34749,6 +35935,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -34780,6 +35972,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -34856,6 +36054,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -34887,6 +36091,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -34963,6 +36173,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -34994,6 +36210,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35070,6 +36292,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -35101,6 +36329,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35177,6 +36411,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -35208,6 +36448,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35284,6 +36530,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -35315,6 +36567,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35391,6 +36649,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -35422,6 +36686,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35498,6 +36768,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -35529,6 +36805,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35605,6 +36887,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -35636,6 +36924,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35712,6 +37006,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -35743,6 +37043,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35819,6 +37125,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -35850,6 +37162,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -35926,6 +37244,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -35957,6 +37281,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -36033,6 +37363,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -36064,6 +37400,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -36140,6 +37482,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -36171,6 +37519,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -36247,6 +37601,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -36278,6 +37638,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -36354,6 +37720,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -36385,6 +37757,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -37631,6 +39009,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -37674,6 +39058,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -37719,6 +39109,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -37762,6 +39158,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -37807,6 +39209,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -37850,6 +39258,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -37895,6 +39309,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -37938,6 +39358,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -37983,6 +39409,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38026,6 +39458,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -38071,6 +39509,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38114,6 +39558,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -38159,6 +39609,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38202,6 +39658,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -38247,6 +39709,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38290,6 +39758,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -38335,6 +39809,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -38378,6 +39858,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -51324,6 +52810,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -51365,6 +52857,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -51464,6 +52962,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -51505,6 +53009,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -51604,6 +53114,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -51645,6 +53161,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -51744,6 +53266,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -51785,6 +53313,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -51884,6 +53418,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -51925,6 +53465,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -52024,6 +53570,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -52065,6 +53617,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -52164,6 +53722,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -52205,6 +53769,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -52304,6 +53874,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -52345,6 +53921,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -52444,6 +54026,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -52485,6 +54073,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -52584,6 +54178,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -52625,6 +54225,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -53010,6 +54616,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -53043,6 +54655,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -53120,6 +54738,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -53153,6 +54777,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -53230,6 +54860,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -53263,6 +54899,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -54921,6 +56563,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -54962,6 +56610,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -55061,6 +56715,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -55102,6 +56762,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -55201,6 +56867,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -55242,6 +56914,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -55341,6 +57019,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -55382,6 +57066,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -55481,6 +57171,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -55522,6 +57218,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -55621,6 +57323,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -55662,6 +57370,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -55761,6 +57475,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -55802,6 +57522,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -55901,6 +57627,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -55942,6 +57674,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -56041,6 +57779,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -56082,6 +57826,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -56181,6 +57931,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -56222,6 +57978,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -56321,6 +58083,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -56362,6 +58130,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -56461,6 +58235,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -56502,6 +58282,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -56601,6 +58387,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -56642,6 +58434,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -56741,6 +58539,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -56782,6 +58586,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -57692,6 +59502,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -57725,6 +59541,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -57898,6 +59720,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -57931,6 +59759,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -58104,6 +59938,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -58137,6 +59977,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -58573,6 +60419,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cost_id",
                     "description": "",
                     "in": "path",
@@ -58614,6 +60466,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "cost_id",
@@ -58713,6 +60571,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cost_id",
                     "description": "",
                     "in": "path",
@@ -58754,6 +60618,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "cost_id",
@@ -58853,6 +60723,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cost_id",
                     "description": "",
                     "in": "path",
@@ -58894,6 +60770,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "cost_id",
@@ -59344,6 +61226,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "assistance_id",
                     "description": "",
                     "in": "path",
@@ -59385,6 +61273,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "assistance_id",
@@ -59484,6 +61378,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "assistance_id",
                     "description": "",
                     "in": "path",
@@ -59525,6 +61425,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "assistance_id",
@@ -59624,6 +61530,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "assistance_id",
                     "description": "",
                     "in": "path",
@@ -59665,6 +61577,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "assistance_id",
@@ -59817,6 +61735,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -59958,6 +61882,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -59991,6 +61921,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -60068,6 +62004,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -60113,6 +62055,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -60158,6 +62106,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -60576,7 +62530,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -60705,6 +62666,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -60747,7 +62714,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -60798,6 +62772,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -60829,6 +62809,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -60905,6 +62891,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "username",
                     "description": "",
                     "in": "path",
@@ -60936,6 +62928,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "username",
                     "description": "",
@@ -61272,6 +63270,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -61303,6 +63307,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -61379,6 +63389,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -61410,6 +63426,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -61486,6 +63508,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -61517,6 +63545,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -61593,6 +63627,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -61624,6 +63664,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -61676,7 +63722,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -61697,7 +63750,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -61741,6 +63801,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "username",
                     "description": "",
                     "in": "path",
@@ -61772,6 +63838,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "username",
                     "description": "",
@@ -61879,7 +63951,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -62202,6 +64281,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -62233,6 +64318,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -62309,6 +64400,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -62340,6 +64437,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -62415,6 +64518,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -62599,6 +64708,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "users_id",
                     "description": "",
                     "in": "path",
@@ -62640,6 +64755,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "users_id",
                     "description": "",
@@ -62853,6 +64974,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -62894,6 +65021,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -64368,6 +66501,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -64399,6 +66538,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -64475,6 +66620,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -64506,6 +66657,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -64582,6 +66739,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -64613,6 +66776,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -64689,6 +66858,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -64720,6 +66895,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -64796,6 +66977,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -64827,6 +67014,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -64903,6 +67096,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -64934,6 +67133,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -65010,6 +67215,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -65041,6 +67252,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -65117,6 +67334,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -65148,6 +67371,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -65224,6 +67453,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -65255,6 +67490,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -65331,6 +67572,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -65362,6 +67609,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -65438,6 +67691,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -65469,6 +67728,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -65545,6 +67810,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -65576,6 +67847,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -65652,6 +67929,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -65683,6 +67966,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -65855,6 +68144,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cost_id",
                     "description": "",
                     "in": "path",
@@ -65886,6 +68181,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "cost_id",
                     "description": "",
@@ -66196,6 +68497,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -66237,6 +68544,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -66333,6 +68646,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -66374,6 +68693,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -66704,6 +69029,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -66745,6 +69076,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -66841,6 +69178,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -66882,6 +69225,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -67095,6 +69444,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -67136,6 +69491,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -67690,6 +70051,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -67731,6 +70098,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -67827,6 +70200,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -67868,6 +70247,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -67964,6 +70349,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -68005,6 +70396,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -68101,6 +70498,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -68142,6 +70545,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -68334,6 +70743,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -68365,6 +70780,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -68537,6 +70958,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -68568,6 +70995,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -68859,6 +71292,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cost_id",
                     "description": "",
                     "in": "path",
@@ -68890,6 +71329,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "cost_id",
                     "description": "",
@@ -69083,6 +71528,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -69124,6 +71575,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -69327,6 +71784,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -69368,6 +71831,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -77407,6 +79876,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -77440,6 +79915,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -77517,6 +79998,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -77550,6 +80037,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -77627,6 +80120,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -77660,6 +80159,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -77737,6 +80242,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -77770,6 +80281,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -77847,6 +80364,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -77880,6 +80403,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -77957,6 +80486,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -77990,6 +80525,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -78067,6 +80608,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -78100,6 +80647,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -78177,6 +80730,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -78210,6 +80769,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -78287,6 +80852,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -78320,6 +80891,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -78397,6 +80974,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -78430,6 +81013,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -78507,6 +81096,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -78540,6 +81135,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -78617,6 +81218,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -78650,6 +81257,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -78727,6 +81340,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -78760,6 +81379,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -78837,6 +81462,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -78870,6 +81501,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -78947,6 +81584,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -78980,6 +81623,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -79057,6 +81706,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -79090,6 +81745,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -79167,6 +81828,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -79200,6 +81867,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -79277,6 +81950,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -79310,6 +81989,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -79387,6 +82072,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -79420,6 +82111,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -79497,6 +82194,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -79530,6 +82233,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -79607,6 +82316,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -79640,6 +82355,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -79717,6 +82438,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -79750,6 +82477,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -79827,6 +82560,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -79860,6 +82599,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -79937,6 +82682,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -79970,6 +82721,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -80047,6 +82804,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -80080,6 +82843,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -80157,6 +82926,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -80190,6 +82965,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -80267,6 +83048,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -80300,6 +83087,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -80377,6 +83170,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -80410,6 +83209,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -80487,6 +83292,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -80520,6 +83331,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -80597,6 +83414,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -80630,6 +83453,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -80707,6 +83536,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -80740,6 +83575,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -80817,6 +83658,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -80850,6 +83697,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -80927,6 +83780,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -80960,6 +83819,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -81037,6 +83902,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -81070,6 +83941,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -81147,6 +84024,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -81180,6 +84063,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -81257,6 +84146,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -81290,6 +84185,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -81367,6 +84268,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -81400,6 +84307,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -81477,6 +84390,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -81510,6 +84429,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -81587,6 +84512,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -81620,6 +84551,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -81697,6 +84634,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -81730,6 +84673,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -81807,6 +84756,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -81840,6 +84795,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -81917,6 +84878,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -81950,6 +84917,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -82027,6 +85000,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -82060,6 +85039,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -82137,6 +85122,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -82170,6 +85161,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -82247,6 +85244,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -82280,6 +85283,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -82357,6 +85366,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -82390,6 +85405,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -82467,6 +85488,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -82500,6 +85527,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -82577,6 +85610,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -82610,6 +85649,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -82687,6 +85732,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -82720,6 +85771,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -82797,6 +85854,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -82830,6 +85893,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -82907,6 +85976,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -82940,6 +86015,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83017,6 +86098,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83050,6 +86137,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83127,6 +86220,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83160,6 +86259,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83237,6 +86342,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83270,6 +86381,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83347,6 +86464,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83380,6 +86503,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83457,6 +86586,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83490,6 +86625,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83567,6 +86708,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83600,6 +86747,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83677,6 +86830,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83710,6 +86869,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83787,6 +86952,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83820,6 +86991,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83897,6 +87074,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83930,6 +87113,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84007,6 +87196,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84040,6 +87235,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84117,6 +87318,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84150,6 +87357,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84227,6 +87440,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84260,6 +87479,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84337,6 +87562,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84370,6 +87601,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84447,6 +87684,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84480,6 +87723,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84557,6 +87806,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84590,6 +87845,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84667,6 +87928,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84700,6 +87967,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84777,6 +88050,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84810,6 +88089,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84887,6 +88172,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84920,6 +88211,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84997,6 +88294,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85030,6 +88333,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -85107,6 +88416,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85140,6 +88455,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -85217,6 +88538,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85250,6 +88577,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -85327,6 +88660,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85360,6 +88699,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -85437,6 +88782,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85470,6 +88821,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -89985,6 +93342,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -90026,6 +93389,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -90102,6 +93471,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -90143,6 +93518,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -90219,6 +93600,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -90260,6 +93647,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -90336,6 +93729,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -90377,6 +93776,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -90453,6 +93858,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -90494,6 +93905,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -90570,6 +93987,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -90611,6 +94034,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -90687,6 +94116,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -90728,6 +94163,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -90804,6 +94245,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -90845,6 +94292,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -90921,6 +94374,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -90962,6 +94421,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -91038,6 +94503,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -91079,6 +94550,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -91155,6 +94632,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -91196,6 +94679,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -91866,6 +95355,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -91917,6 +95412,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -92016,6 +95517,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -92067,6 +95574,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -92166,6 +95679,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -92217,6 +95736,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -92316,6 +95841,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -92367,6 +95898,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -92466,6 +96003,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -92517,6 +96060,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -92616,6 +96165,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -92667,6 +96222,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -92766,6 +96327,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -92817,6 +96384,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -92916,6 +96489,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -92967,6 +96546,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -93066,6 +96651,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -93117,6 +96708,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -93216,6 +96813,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -93267,6 +96870,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -93366,6 +96975,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -93417,6 +97032,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -94099,6 +97720,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -94150,6 +97777,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -94249,6 +97882,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -94300,6 +97939,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -94399,6 +98044,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -94450,6 +98101,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -94549,6 +98206,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -94600,6 +98263,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -94699,6 +98368,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -94750,6 +98425,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -94849,6 +98530,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -94900,6 +98587,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -94999,6 +98692,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -95050,6 +98749,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -95149,6 +98854,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -95200,6 +98911,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -95299,6 +99016,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -95350,6 +99073,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -95449,6 +99178,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -95500,6 +99235,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -95599,6 +99340,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -95650,6 +99397,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -97224,6 +100977,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -97255,6 +101014,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -97331,6 +101096,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -97362,6 +101133,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -99058,6 +102835,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99089,6 +102872,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -99165,6 +102954,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99196,6 +102991,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -99272,6 +103073,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99303,6 +103110,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -99379,6 +103192,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99410,6 +103229,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -99486,6 +103311,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99517,6 +103348,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -99593,6 +103430,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99624,6 +103467,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -99700,6 +103549,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99731,6 +103586,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -99807,6 +103668,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99838,6 +103705,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -99914,6 +103787,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99945,6 +103824,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -100021,6 +103906,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -100052,6 +103943,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -100128,6 +104025,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -100159,6 +104062,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -100235,6 +104144,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -100266,6 +104181,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -100342,6 +104263,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -100373,6 +104300,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -100449,6 +104382,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -100480,6 +104419,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -100556,6 +104501,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -100587,6 +104538,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -100663,6 +104620,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -100694,6 +104657,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -100770,6 +104739,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "context",
                     "description": "",
                     "in": "path",
@@ -100830,6 +104805,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "context",
                     "description": "",
@@ -101035,7 +105016,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -101057,6 +105045,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -101500,6 +105494,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -105067,6 +109067,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -105108,6 +109114,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -105194,6 +109206,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -105235,6 +109253,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -105321,6 +109345,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -105362,6 +109392,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -105448,6 +109484,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -105489,6 +109531,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -105575,6 +109623,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -105616,6 +109670,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -105702,6 +109762,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -105743,6 +109809,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -105829,6 +109901,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -105870,6 +109948,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -105956,6 +110040,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -105997,6 +110087,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -106083,6 +110179,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -106124,6 +110226,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -106210,6 +110318,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -106251,6 +110365,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -106337,6 +110457,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -106378,6 +110504,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -106464,6 +110596,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -106505,6 +110643,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -106591,6 +110735,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -106632,6 +110782,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -106718,6 +110874,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -106759,6 +110921,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -106845,6 +111013,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -106886,6 +111060,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -106972,6 +111152,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -107013,6 +111199,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -107099,6 +111291,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -107140,6 +111338,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -107226,6 +111430,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -107267,6 +111477,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -107353,6 +111569,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -107394,6 +111616,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -107480,6 +111708,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -107521,6 +111755,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -107607,6 +111847,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -107648,6 +111894,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -107734,6 +111986,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -107775,6 +112033,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -107861,6 +112125,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -107902,6 +112172,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -107988,6 +112264,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -108029,6 +112311,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -108115,6 +112403,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -108156,6 +112450,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -108242,6 +112542,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -108283,6 +112589,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -108369,6 +112681,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -108410,6 +112728,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -108496,6 +112820,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -108537,6 +112867,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -108623,6 +112959,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -108664,6 +113006,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -108750,6 +113098,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -108791,6 +113145,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -109026,6 +113386,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -109070,6 +113436,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -109288,6 +113660,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -109332,6 +113710,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -109583,6 +113967,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -109638,6 +114028,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -109825,6 +114221,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -109958,6 +114360,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -110241,6 +114649,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -110272,6 +114686,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -110348,6 +114768,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -110379,6 +114805,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -110455,6 +114887,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -110486,6 +114924,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -110772,6 +115216,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -110957,6 +115407,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -110988,6 +115444,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -111181,6 +115643,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -111363,6 +115831,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -111394,6 +115868,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -111587,6 +116067,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -111628,6 +116114,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -111724,6 +116216,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "template_id",
                     "description": "",
                     "in": "path",
@@ -111777,6 +116275,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "template_id",
                     "description": "",
@@ -111908,6 +116412,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",

--- a/tests/fixtures/hlapi/snapshots/2.4.0/components.json
+++ b/tests/fixtures/hlapi/snapshots/2.4.0/components.json
@@ -14492,7 +14492,9 @@
                 "size": {
                     "type": "number",
                     "format": "float",
-                    "minimum": 0
+                    "minimum": 0,
+                    "maximum": 999.99,
+                    "multipleOf": 0.01
                 },
                 "has_microphone": {
                     "type": "boolean",

--- a/tests/fixtures/hlapi/snapshots/2.4.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.4.0/paths.json
@@ -1775,6 +1775,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -1808,6 +1814,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -1885,6 +1897,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -1918,6 +1936,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -1995,6 +2019,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2028,6 +2058,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2105,6 +2141,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2138,6 +2180,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2215,6 +2263,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2248,6 +2302,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2325,6 +2385,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2358,6 +2424,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2435,6 +2507,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2468,6 +2546,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2545,6 +2629,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2578,6 +2668,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2655,6 +2751,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2688,6 +2790,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2765,6 +2873,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2798,6 +2912,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -2875,6 +2995,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -2961,6 +3087,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3038,6 +3170,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3124,6 +3262,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3201,6 +3345,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3287,6 +3437,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3364,6 +3520,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3450,6 +3612,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3527,6 +3695,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3613,6 +3787,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3690,6 +3870,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3776,6 +3962,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -3853,6 +4045,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -3939,6 +4137,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4016,6 +4220,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4102,6 +4312,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4179,6 +4395,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4265,6 +4487,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4342,6 +4570,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4428,6 +4662,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4505,6 +4745,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4591,6 +4837,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4668,6 +4920,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4754,6 +5012,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4831,6 +5095,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -4917,6 +5187,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -4994,6 +5270,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5080,6 +5362,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5157,6 +5445,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5243,6 +5537,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5320,6 +5620,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5406,6 +5712,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5483,6 +5795,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5569,6 +5887,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5646,6 +5970,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5732,6 +6062,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -5809,6 +6145,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -5895,6 +6237,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -6068,6 +6416,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -6101,6 +6455,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -6180,6 +6540,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cartridgeitems_id",
                     "description": "",
                     "in": "path",
@@ -6221,6 +6587,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "cartridgeitems_id",
@@ -6468,6 +6840,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -6501,6 +6879,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -6580,6 +6964,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "consumableitems_id",
                     "description": "",
                     "in": "path",
@@ -6621,6 +7011,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "consumableitems_id",
@@ -6868,6 +7264,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -6901,6 +7303,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -7074,6 +7482,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -7107,6 +7521,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -7303,6 +7723,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "rack_id",
                     "description": "",
                     "in": "path",
@@ -7344,6 +7770,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "rack_id",
@@ -7537,6 +7969,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -7570,6 +8008,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -7743,6 +8187,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -7776,6 +8226,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -7949,6 +8405,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -7982,6 +8444,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -8155,6 +8623,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -8188,6 +8662,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -8361,6 +8841,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -8394,6 +8880,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -8590,6 +9082,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "software_id",
                     "description": "",
                     "in": "path",
@@ -8631,6 +9129,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "software_id",
@@ -8797,7 +9301,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -8818,7 +9329,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9671,7 +10189,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9692,7 +10217,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9745,7 +10277,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9766,7 +10305,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9819,7 +10365,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9840,7 +10393,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9893,7 +10453,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9914,7 +10481,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -9967,7 +10541,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -9988,7 +10569,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10041,7 +10629,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10062,7 +10657,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10115,7 +10717,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10136,7 +10745,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10189,7 +10805,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10210,7 +10833,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10263,7 +10893,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10284,7 +10921,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -10337,7 +10981,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -10358,7 +11009,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11211,7 +11869,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11232,7 +11897,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11285,7 +11957,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11306,7 +11985,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11359,7 +12045,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11380,7 +12073,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11433,7 +12133,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11454,7 +12161,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11507,7 +12221,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11528,7 +12249,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11581,7 +12309,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11602,7 +12337,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11655,7 +12397,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11676,7 +12425,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11729,7 +12485,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11750,7 +12513,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11803,7 +12573,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11824,7 +12601,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -11877,7 +12661,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -11898,7 +12689,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -12751,7 +13549,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -12772,7 +13577,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -12825,7 +13637,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -12846,7 +13665,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -12899,7 +13725,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -12920,7 +13753,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -12973,7 +13813,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -12994,7 +13841,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -13047,7 +13901,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -13068,7 +13929,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -13121,7 +13989,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -13142,7 +14017,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -13195,7 +14077,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -13216,7 +14105,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -13269,7 +14165,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -13290,7 +14193,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -13343,7 +14253,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -13364,7 +14281,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -13417,7 +14341,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -13438,7 +14369,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14291,7 +15229,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14312,7 +15257,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14365,7 +15317,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14386,7 +15345,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14439,7 +15405,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14460,7 +15433,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14513,7 +15493,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14534,7 +15521,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14587,7 +15581,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14608,7 +15609,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14661,7 +15669,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14682,7 +15697,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14735,7 +15757,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14756,7 +15785,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14809,7 +15845,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14830,7 +15873,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14883,7 +15933,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14904,7 +15961,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -14957,7 +16021,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -14978,7 +16049,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -15831,7 +16909,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -15852,7 +16937,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -15905,7 +16997,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -15926,7 +17025,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -15979,7 +17085,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16000,7 +17113,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16053,7 +17173,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16074,7 +17201,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16127,7 +17261,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16148,7 +17289,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16201,7 +17349,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16222,7 +17377,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16275,7 +17437,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16296,7 +17465,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16349,7 +17525,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16370,7 +17553,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16423,7 +17613,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16444,7 +17641,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -16497,7 +17701,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -16518,7 +17729,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -17012,7 +18230,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17056,7 +18281,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17100,7 +18332,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17144,7 +18383,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17188,7 +18434,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17232,7 +18485,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17276,7 +18536,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17320,7 +18587,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17364,7 +18638,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -17408,7 +18689,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -21333,6 +22621,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -21377,6 +22671,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -21476,6 +22776,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -21520,6 +22826,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -21619,6 +22931,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -21663,6 +22981,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -21762,6 +23086,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -21806,6 +23136,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -21905,6 +23241,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -21949,6 +23291,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -22048,6 +23396,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -22092,6 +23446,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -22191,6 +23551,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -22235,6 +23601,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -22334,6 +23706,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -22378,6 +23756,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -22477,6 +23861,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -22521,6 +23911,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -22620,6 +24016,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -22664,6 +24066,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -23596,6 +25004,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -23640,6 +25054,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -23739,6 +25159,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -23783,6 +25209,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -23882,6 +25314,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -23926,6 +25364,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -24025,6 +25469,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -24069,6 +25519,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -24168,6 +25624,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -24212,6 +25674,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -24311,6 +25779,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -24355,6 +25829,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -24454,6 +25934,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -24498,6 +25984,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -25668,6 +27160,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -25712,6 +27210,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -25811,6 +27315,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -25855,6 +27365,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -25954,6 +27470,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -25998,6 +27520,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -26097,6 +27625,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -26141,6 +27675,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -26240,6 +27780,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -26284,6 +27830,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -26383,6 +27935,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -26427,6 +27985,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -26526,6 +28090,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -26570,6 +28140,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -26669,6 +28245,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -26713,6 +28295,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -26812,6 +28400,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -26856,6 +28450,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -27550,6 +29150,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -27594,6 +29200,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -27693,6 +29305,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -27737,6 +29355,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -27836,6 +29460,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -27880,6 +29510,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -27979,6 +29615,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -28023,6 +29665,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -28122,6 +29770,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -28166,6 +29820,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -29455,6 +31115,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -29499,6 +31165,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -29598,6 +31270,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -29642,6 +31320,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -29741,6 +31425,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -29785,6 +31475,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -29884,6 +31580,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -29928,6 +31630,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30027,6 +31735,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30071,6 +31785,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30170,6 +31890,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30214,6 +31940,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30313,6 +32045,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30357,6 +32095,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30456,6 +32200,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30500,6 +32250,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30599,6 +32355,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30643,6 +32405,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -30742,6 +32510,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -30786,6 +32560,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -32551,6 +34331,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -32595,6 +34381,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -32694,6 +34486,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -32738,6 +34536,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -32837,6 +34641,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -32881,6 +34691,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -32980,6 +34796,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -33024,6 +34846,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -33123,6 +34951,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -33167,6 +35001,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -33266,6 +35106,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -33310,6 +35156,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -33409,6 +35261,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -33453,6 +35311,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -33552,6 +35416,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -33596,6 +35466,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -33695,6 +35571,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -33739,6 +35621,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -33838,6 +35726,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -33882,6 +35776,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -33981,6 +35881,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -34025,6 +35931,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -34124,6 +36036,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -34168,6 +36086,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -34267,6 +36191,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -34311,6 +36241,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -34410,6 +36346,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -34454,6 +36396,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -34583,3096 +36531,6 @@
                 }
             },
             "parameters": [],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21162": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21162"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21162"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21162"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21162"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21424": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21424"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21424"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21424"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21424"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Car": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Car"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Car"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Car"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Car"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21724": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21724"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21724"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21724"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21724"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/AllCapacities": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_AllCapacities"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_AllCapacities"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_AllCapacities"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_AllCapacities"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21162/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21162"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21162"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21162"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21162"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21162"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21424/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21424"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21424"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21424"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21424"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21424"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Car/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Car"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Car"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Car"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Car"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Car"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21724/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21724"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21724"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21724"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21724"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21724"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/AllCapacities/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_AllCapacities"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_AllCapacities"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_AllCapacities"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_AllCapacities"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_AllCapacities"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21162Model": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21162Model"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21162Model"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21162Model"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21162Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21424Model": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21424Model"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21424Model"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21424Model"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21424Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/CarModel": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_CarModel"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_CarModel"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_CarModel"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_CarModel"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21724Model": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21724Model"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21724Model"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21724Model"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21724Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/AllCapacitiesModel": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_AllCapacitiesModel"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_AllCapacitiesModel"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_AllCapacitiesModel"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_AllCapacitiesModel"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21162Model/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21162Model"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21162Model"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21162Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21162Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21162Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21424Model/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21424Model"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21424Model"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21424Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21424Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21424Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/CarModel/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_CarModel"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_CarModel"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_CarModel"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_CarModel"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_CarModel"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21724Model/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21724Model"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21724Model"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21724Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21724Model"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21724Model"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/AllCapacitiesModel/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_AllCapacitiesModel"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_AllCapacitiesModel"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_AllCapacitiesModel"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_AllCapacitiesModel"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_AllCapacitiesModel"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21162Type": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21162Type"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21162Type"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21162Type"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21162Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21424Type": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21424Type"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21424Type"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21424Type"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21424Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/CarType": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_CarType"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_CarType"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_CarType"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_CarType"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21724Type": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21724Type"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21724Type"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_Issue21724Type"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21724Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/AllCapacitiesType": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_AllCapacitiesType"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_AllCapacitiesType"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CustomAsset_AllCapacitiesType"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_AllCapacitiesType"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21162Type/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21162Type"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21162Type"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21162Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21162Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21162Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21424Type/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21424Type"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21424Type"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21424Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21424Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21424Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/CarType/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_CarType"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_CarType"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_CarType"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_CarType"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_CarType"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/Issue21724Type/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21724Type"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21724Type"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21724Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_Issue21724Type"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_Issue21724Type"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Assets/Custom/AllCapacitiesType/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_AllCapacitiesType"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_AllCapacitiesType"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_AllCapacitiesType"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CustomAsset_AllCapacitiesType"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CustomAsset_AllCapacitiesType"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the Asset",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
             "security": [
                 {
                     "oauth": [
@@ -39519,6 +38377,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -39550,6 +38414,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -39626,6 +38496,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -39657,6 +38533,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -39733,6 +38615,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -39764,6 +38652,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -39840,6 +38734,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -39871,6 +38771,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -39947,6 +38853,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -39978,6 +38890,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40054,6 +38972,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40085,6 +39009,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40161,6 +39091,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40192,6 +39128,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40268,6 +39210,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40299,6 +39247,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40375,6 +39329,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40406,6 +39366,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40482,6 +39448,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40513,6 +39485,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40589,6 +39567,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40620,6 +39604,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40696,6 +39686,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40727,6 +39723,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40803,6 +39805,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40834,6 +39842,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -40910,6 +39924,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -40941,6 +39961,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -41017,6 +40043,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -41048,6 +40080,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -41124,6 +40162,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -41155,6 +40199,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -41231,6 +40281,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -41262,6 +40318,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -41338,6 +40400,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -41369,6 +40437,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -42615,6 +41689,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42658,6 +41738,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -42703,6 +41789,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42746,6 +41838,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -42791,6 +41889,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42834,6 +41938,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -42879,6 +41989,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -42922,6 +42038,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -42967,6 +42089,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -43010,6 +42138,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -43055,6 +42189,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -43098,6 +42238,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -43143,6 +42289,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -43186,6 +42338,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -43231,6 +42389,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -43274,6 +42438,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -43319,6 +42489,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -43362,6 +42538,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -56308,6 +55490,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -56349,6 +55537,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -56448,6 +55642,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -56489,6 +55689,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -56588,6 +55794,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -56629,6 +55841,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -56728,6 +55946,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -56769,6 +55993,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -56868,6 +56098,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -56909,6 +56145,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -57008,6 +56250,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -57049,6 +56297,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -57148,6 +56402,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -57189,6 +56449,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -57288,6 +56554,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -57329,6 +56601,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -57428,6 +56706,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -57469,6 +56753,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -57568,6 +56858,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -57609,6 +56905,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -57994,6 +57296,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -58027,6 +57335,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -58104,6 +57418,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -58137,6 +57457,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -58214,6 +57540,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -58247,6 +57579,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -59905,6 +59243,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -59946,6 +59290,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -60045,6 +59395,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -60086,6 +59442,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -60185,6 +59547,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -60226,6 +59594,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -60325,6 +59699,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -60366,6 +59746,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -60465,6 +59851,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -60506,6 +59898,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -60605,6 +60003,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -60646,6 +60050,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -60745,6 +60155,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -60786,6 +60202,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -60885,6 +60307,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -60926,6 +60354,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -61025,6 +60459,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -61066,6 +60506,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -61165,6 +60611,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -61206,6 +60658,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -61305,6 +60763,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -61346,6 +60810,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -61445,6 +60915,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -61486,6 +60962,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -61585,6 +61067,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -61626,6 +61114,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -61725,6 +61219,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "subitem_id",
                     "description": "",
                     "in": "path",
@@ -61766,6 +61266,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "subitem_id",
@@ -62676,6 +62182,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -62709,6 +62221,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -62882,6 +62400,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -62915,6 +62439,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -63088,6 +62618,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -63121,6 +62657,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -63557,6 +63099,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cost_id",
                     "description": "",
                     "in": "path",
@@ -63598,6 +63146,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "cost_id",
@@ -63697,6 +63251,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cost_id",
                     "description": "",
                     "in": "path",
@@ -63738,6 +63298,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "cost_id",
@@ -63837,6 +63403,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cost_id",
                     "description": "",
                     "in": "path",
@@ -63878,6 +63450,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "cost_id",
@@ -64328,6 +63906,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "assistance_id",
                     "description": "",
                     "in": "path",
@@ -64369,6 +63953,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "assistance_id",
@@ -64468,6 +64058,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "assistance_id",
                     "description": "",
                     "in": "path",
@@ -64509,6 +64105,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "assistance_id",
@@ -64608,6 +64210,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "assistance_id",
                     "description": "",
                     "in": "path",
@@ -64649,6 +64257,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "assistance_id",
@@ -64801,6 +64415,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -64942,6 +64562,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -64975,6 +64601,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -65052,6 +64684,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -65097,6 +64735,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -65142,6 +64786,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -65560,7 +65210,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -65689,6 +65346,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -65731,7 +65394,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -65869,6 +65539,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "users_id",
                     "description": "",
                     "in": "path",
@@ -65970,6 +65646,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -66001,6 +65683,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -66077,6 +65765,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "username",
                     "description": "",
                     "in": "path",
@@ -66108,6 +65802,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "username",
                     "description": "",
@@ -66444,6 +66144,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -66475,6 +66181,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -66551,6 +66263,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -66582,6 +66300,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -66658,6 +66382,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -66689,6 +66419,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -66765,6 +66501,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -66796,6 +66538,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -66848,7 +66596,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -66869,7 +66624,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -66913,6 +66675,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "username",
                     "description": "",
                     "in": "path",
@@ -66944,6 +66712,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "username",
                     "description": "",
@@ -67051,7 +66825,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -67374,6 +67155,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -67405,6 +67192,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -67481,6 +67274,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -67512,6 +67311,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -67587,6 +67392,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -67771,6 +67582,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "users_id",
                     "description": "",
                     "in": "path",
@@ -67812,6 +67629,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "users_id",
                     "description": "",
@@ -68025,6 +67848,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -68066,6 +67895,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -69540,6 +69375,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -69571,6 +69412,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -69647,6 +69494,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -69678,6 +69531,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -69754,6 +69613,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -69785,6 +69650,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -69861,6 +69732,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -69892,6 +69769,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -69968,6 +69851,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -69999,6 +69888,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -70075,6 +69970,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -70106,6 +70007,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -70182,6 +70089,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -70213,6 +70126,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -70289,6 +70208,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -70320,6 +70245,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -70396,6 +70327,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -70427,6 +70364,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -70503,6 +70446,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -70534,6 +70483,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -70610,6 +70565,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -70641,6 +70602,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -70717,6 +70684,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -70748,6 +70721,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -70824,6 +70803,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -70855,6 +70840,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -71027,6 +71018,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cost_id",
                     "description": "",
                     "in": "path",
@@ -71058,6 +71055,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "cost_id",
                     "description": "",
@@ -71368,6 +71371,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -71409,6 +71418,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -71505,6 +71520,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -71546,6 +71567,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -71876,6 +71903,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -71917,6 +71950,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -72013,6 +72052,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -72054,6 +72099,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -72267,6 +72318,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -72308,6 +72365,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -72862,6 +72925,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -72903,6 +72972,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -72999,6 +73074,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -73040,6 +73121,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -73136,6 +73223,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -73177,6 +73270,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -73273,6 +73372,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -73314,6 +73419,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -73506,6 +73617,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -73537,6 +73654,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -73709,6 +73832,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -73740,6 +73869,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -74031,6 +74166,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "cost_id",
                     "description": "",
                     "in": "path",
@@ -74062,6 +74203,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "cost_id",
                     "description": "",
@@ -74255,6 +74402,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -74296,6 +74449,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -74499,6 +74658,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -74540,6 +74705,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -82579,6 +82750,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -82612,6 +82789,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -82689,6 +82872,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -82722,6 +82911,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -82799,6 +82994,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -82832,6 +83033,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -82909,6 +83116,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -82942,6 +83155,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83019,6 +83238,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83052,6 +83277,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83129,6 +83360,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83162,6 +83399,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83239,6 +83482,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83272,6 +83521,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83349,6 +83604,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83382,6 +83643,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83459,6 +83726,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83492,6 +83765,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83569,6 +83848,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83602,6 +83887,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83679,6 +83970,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83712,6 +84009,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83789,6 +84092,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83822,6 +84131,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -83899,6 +84214,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -83932,6 +84253,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84009,6 +84336,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84042,6 +84375,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84119,6 +84458,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84152,6 +84497,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84229,6 +84580,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84262,6 +84619,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84339,6 +84702,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84372,6 +84741,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84449,6 +84824,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84482,6 +84863,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84559,6 +84946,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84592,6 +84985,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84669,6 +85068,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84702,6 +85107,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84779,6 +85190,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84812,6 +85229,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84889,6 +85312,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -84922,6 +85351,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -84999,6 +85434,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85032,6 +85473,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -85109,6 +85556,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85142,6 +85595,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -85219,6 +85678,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85252,6 +85717,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -85329,6 +85800,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85362,6 +85839,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -85439,6 +85922,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85472,6 +85961,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -85549,6 +86044,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85582,6 +86083,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -85659,6 +86166,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85692,6 +86205,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -85769,6 +86288,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85802,6 +86327,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -85879,6 +86410,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -85912,6 +86449,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -85989,6 +86532,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -86022,6 +86571,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -86099,6 +86654,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -86132,6 +86693,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -86209,6 +86776,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -86242,6 +86815,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -86319,6 +86898,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -86352,6 +86937,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -86429,6 +87020,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -86462,6 +87059,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -86539,6 +87142,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -86572,6 +87181,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -86649,6 +87264,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -86682,6 +87303,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -86759,6 +87386,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -86792,6 +87425,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -86869,6 +87508,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -86902,6 +87547,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -86979,6 +87630,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -87012,6 +87669,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -87089,6 +87752,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -87122,6 +87791,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -87199,6 +87874,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -87232,6 +87913,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -87309,6 +87996,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -87342,6 +88035,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -87419,6 +88118,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -87452,6 +88157,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -87529,6 +88240,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -87562,6 +88279,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -87639,6 +88362,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -87672,6 +88401,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -87749,6 +88484,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -87782,6 +88523,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -87859,6 +88606,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -87892,6 +88645,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -87969,6 +88728,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -88002,6 +88767,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -88079,6 +88850,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -88112,6 +88889,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -88189,6 +88972,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -88222,6 +89011,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -88299,6 +89094,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -88332,6 +89133,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -88409,6 +89216,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -88442,6 +89255,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -88519,6 +89338,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -88552,6 +89377,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -88629,6 +89460,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -88662,6 +89499,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -88739,6 +89582,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -88772,6 +89621,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -88849,6 +89704,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -88882,6 +89743,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -88959,6 +89826,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -88992,6 +89865,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -89069,6 +89948,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -89102,6 +89987,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -89179,6 +90070,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -89212,6 +90109,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -89289,6 +90192,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -89322,6 +90231,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -89399,6 +90314,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -89432,6 +90353,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -89509,6 +90436,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -89542,6 +90475,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -89619,6 +90558,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -89652,6 +90597,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -89729,6 +90680,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -89762,6 +90719,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -89839,6 +90802,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -89872,6 +90841,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -89949,6 +90924,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -89982,6 +90963,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -90059,6 +91046,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -90092,6 +91085,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -90169,6 +91168,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -90202,6 +91207,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -90279,6 +91290,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -90312,6 +91329,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -90389,6 +91412,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -90422,6 +91451,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -90499,6 +91534,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -90532,6 +91573,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -90609,6 +91656,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -90642,6 +91695,12 @@
                         "format": "int32",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -95157,6 +96216,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -95198,6 +96263,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -95274,6 +96345,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -95315,6 +96392,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -95391,6 +96474,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -95432,6 +96521,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -95508,6 +96603,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -95549,6 +96650,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -95625,6 +96732,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -95666,6 +96779,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -95742,6 +96861,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -95783,6 +96908,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -95859,6 +96990,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -95900,6 +97037,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -95976,6 +97119,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -96017,6 +97166,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -96093,6 +97248,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -96134,6 +97295,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -96210,6 +97377,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -96251,6 +97424,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -96327,6 +97506,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -96368,6 +97553,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -97038,6 +98229,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -97089,6 +98286,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -97188,6 +98391,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -97239,6 +98448,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -97338,6 +98553,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -97389,6 +98610,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -97488,6 +98715,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -97539,6 +98772,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -97638,6 +98877,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -97689,6 +98934,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -97788,6 +99039,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -97839,6 +99096,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -97938,6 +99201,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -97989,6 +99258,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -98088,6 +99363,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -98139,6 +99420,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -98238,6 +99525,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -98289,6 +99582,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -98388,6 +99687,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -98439,6 +99744,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -98538,6 +99849,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -98589,6 +99906,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -99271,6 +100594,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99322,6 +100651,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -99421,6 +100756,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99472,6 +100813,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -99571,6 +100918,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99622,6 +100975,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -99721,6 +101080,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99772,6 +101137,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -99871,6 +101242,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -99922,6 +101299,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -100021,6 +101404,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -100072,6 +101461,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -100171,6 +101566,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -100222,6 +101623,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -100321,6 +101728,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -100372,6 +101785,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -100471,6 +101890,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -100522,6 +101947,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -100621,6 +102052,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -100672,6 +102109,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -100771,6 +102214,12 @@
                     }
                 },
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -100822,6 +102271,12 @@
                         "format": "int64",
                         "pattern": "\\d+"
                     }
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 },
                 {
                     "name": "id",
@@ -102396,6 +103851,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -102427,6 +103888,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -102503,6 +103970,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -102534,6 +104007,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -102663,7 +104142,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -102725,7 +104211,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "requestBody": {
                 "content": {
                     "application/json": {
@@ -104400,6 +105893,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -104431,6 +105930,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -104507,6 +106012,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -104538,6 +106049,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -104614,6 +106131,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -104645,6 +106168,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -104721,6 +106250,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -104752,6 +106287,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -104828,6 +106369,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -104859,6 +106406,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -104935,6 +106488,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -104966,6 +106525,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -105042,6 +106607,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -105073,6 +106644,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -105149,6 +106726,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -105180,6 +106763,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -105256,6 +106845,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -105287,6 +106882,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -105363,6 +106964,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -105394,6 +107001,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -105470,6 +107083,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -105501,6 +107120,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -105577,6 +107202,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -105608,6 +107239,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -105684,6 +107321,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -105715,6 +107358,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -105791,6 +107440,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -105822,6 +107477,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -105898,6 +107559,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -105929,6 +107596,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -106005,6 +107678,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -106036,6 +107715,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -106112,6 +107797,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "context",
                     "description": "",
                     "in": "path",
@@ -106172,6 +107863,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "context",
                     "description": "",
@@ -106377,7 +108074,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [
@@ -106399,6 +108103,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -106843,6 +108553,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -107005,6 +108721,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -107036,6 +108758,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -107208,6 +108936,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -107239,6 +108973,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -110815,6 +112555,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -110856,6 +112602,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -110942,6 +112694,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -110983,6 +112741,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -111069,6 +112833,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -111110,6 +112880,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -111196,6 +112972,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -111237,6 +113019,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -111323,6 +113111,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -111364,6 +113158,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -111450,6 +113250,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -111491,6 +113297,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -111577,6 +113389,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -111618,6 +113436,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -111704,6 +113528,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -111745,6 +113575,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -111831,6 +113667,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -111872,6 +113714,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -111958,6 +113806,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -111999,6 +113853,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -112085,6 +113945,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -112126,6 +113992,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -112212,6 +114084,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -112253,6 +114131,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -112339,6 +114223,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -112380,6 +114270,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -112466,6 +114362,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -112507,6 +114409,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -112593,6 +114501,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -112634,6 +114548,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -112720,6 +114640,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -112761,6 +114687,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -112847,6 +114779,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -112888,6 +114826,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -112974,6 +114918,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -113015,6 +114965,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -113101,6 +115057,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -113142,6 +115104,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -113228,6 +115196,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -113269,6 +115243,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -113355,6 +115335,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -113396,6 +115382,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -113482,6 +115474,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -113523,6 +115521,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -113609,6 +115613,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -113650,6 +115660,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -113736,6 +115752,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -113777,6 +115799,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -113863,6 +115891,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -113904,6 +115938,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -113990,6 +116030,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -114031,6 +116077,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -114117,6 +116169,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -114158,6 +116216,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -114244,6 +116308,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -114285,6 +116355,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -114371,6 +116447,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -114412,6 +116494,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -114498,6 +116586,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "items_id",
                     "description": "",
                     "in": "path",
@@ -114539,6 +116633,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "items_id",
                     "description": "",
@@ -114774,6 +116874,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -114818,6 +116924,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -115036,6 +117148,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -115080,6 +117198,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -115331,6 +117455,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -115386,6 +117516,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "requestBody": {
@@ -115573,6 +117709,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -115706,6 +117848,12 @@
                         "format": "string"
                     },
                     "example": null
+                },
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
                 }
             ],
             "security": [
@@ -115989,6 +118137,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -116020,6 +118174,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -116096,6 +118256,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -116127,6 +118293,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -116203,6 +118375,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -116234,6 +118412,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -116520,6 +118704,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -116705,6 +118895,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -116736,6 +118932,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -116929,6 +119131,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -117111,6 +119319,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -117142,6 +119356,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -117335,6 +119555,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -117376,6 +119602,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -117472,6 +119704,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "template_id",
                     "description": "",
                     "in": "path",
@@ -117525,6 +119763,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "template_id",
                     "description": "",
@@ -117657,6 +119901,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -117709,7 +119959,14 @@
                     }
                 }
             },
-            "parameters": [],
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                }
+            ],
             "security": [
                 {
                     "oauth": [

--- a/tests/functional/Glpi/Api/HL/ResourceAccessorTest.php
+++ b/tests/functional/Glpi/Api/HL/ResourceAccessorTest.php
@@ -38,6 +38,8 @@ use Glpi\Api\HL\Controller\AbstractController;
 use Glpi\Api\HL\ResourceAccessor;
 use Glpi\Tests\GLPITestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionMethod;
+use Ticket;
 
 class ResourceAccessorTest extends GLPITestCase
 {
@@ -195,5 +197,31 @@ class ResourceAccessorTest extends GLPITestCase
                 'maximum' => 300,
             ],
         ], $response_data['detail']['weight']);
+    }
+
+    public function testValidatePreconditions(): void
+    {
+        $ticket = new Ticket();
+        $ticket->fields = [
+            'id' => 1,
+            'name' => 'Test Ticket',
+            'content' => 'This is a test ticket.',
+            'date_mod' => '2026-09-01 12:00:00',
+        ];
+        $rm = new ReflectionMethod(ResourceAccessor::class, 'validatePreconditions');
+
+        $this->assertEmpty($rm->invoke(null, $ticket, [
+            'If-Modified-Since' => ['2026-08-15 12:00:00'],
+        ]));
+        $this->assertArrayHasKey('If-Modified-Since', $rm->invoke(null, $ticket, [
+            'If-Modified-Since' => ['2026-09-02 2:00:00'],
+        ]));
+
+        $this->assertEmpty($rm->invoke(null, $ticket, [
+            'If-Unmodified-Since' => ['2026-09-02 12:00:00'],
+        ]));
+        $this->assertArrayHasKey('If-Unmodified-Since', $rm->invoke(null, $ticket, [
+            'If-Unmodified-Since' => ['2026-08-15 12:00:00'],
+        ]));
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Some HTTP conditional headers could be supported to improve user experience and add fine-control the behavior of the API. This PR only focuses on preconditions related to the resource modification date.

- `If-Unmodified-Since`: Could be used to warn or prevent making changes to a resource that had been changed by another user after it was loaded by the client. Returns 412 status when condition not met.
- `If-Modified-Since`: Could be used with GET method to efficiently fetch resources only if they changed since the last time. Returns 304 status when unmet for GET request or 412 for other requests.

For example, with a frontend view of the ticket:
- The client requests Ticket 10 to populate the fields in the right-side panel.
- The user adds a followup which refreshes the just the timeline/the timeline updates on a timer.
- The client sends a request to get Ticket 10 again but this time with If-Modified-Since.
- The server can efficiently skip returning the data if it hasn’t changed.
- The client gets a 304 Not Modified response and can efficiently skip updating the fields.