### PR TITLE
FIX / Allow attaching a document to an item the user can only view

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2465,6 +2465,13 @@ class CommonDBTM extends CommonGLPI
      */
     public function canAddItem(string $type): bool
     {
+        if ($type === Document::class) {
+            // "One write is enough". Stricter itemtypes (e.g. no document on a closed
+            // ticket) override this method and keep their own rule.
+            return $this->can($this->getID(), UPDATE)
+                || (Session::haveRight(Document::$rightname, CREATE) && $this->can($this->getID(), READ));
+        }
+
         return $this->can($this->getID(), UPDATE);
     }
 

--- a/src/Document.php
+++ b/src/Document.php
@@ -141,7 +141,10 @@ class Document extends CommonDBTM implements TreeBrowseInterface
                 ($item = getItemForItemtype($this->input['itemtype']))
                 && $item->getFromDB($this->input['items_id'])
             ) {
-                return $item->canAddItem('Document');
+                // "One write is enough": allow if user can edit the linked item, or may
+                // create the document itself while being able to view that item.
+                return $item->canAddItem('Document')
+                    || (self::canCreate() && $item->can($this->input['items_id'], READ) && parent::canCreateItem());
             } else {
                 unset($this->input['itemtype'], $this->input['items_id']);
             }

--- a/src/Document.php
+++ b/src/Document.php
@@ -134,16 +134,6 @@ class Document extends CommonDBTM implements TreeBrowseInterface
               || Session::haveRight('followup', ITILFollowup::ADDMY));
     }
 
-    /**
-     * Can the current user attach a document to $item?
-     * True when they can edit the item, or hold the document CREATE right while being able to view it.
-     */
-    public static function canAttachToItem(CommonDBTM $item): bool
-    {
-        return $item->canAddItem('Document')
-            || (Session::haveRight(self::$rightname, CREATE) && $item->can($item->getID(), READ));
-    }
-
     public function canCreateItem(): bool
     {
         if (isset($this->input['itemtype'], $this->input['items_id'])) {
@@ -151,10 +141,9 @@ class Document extends CommonDBTM implements TreeBrowseInterface
                 ($item = getItemForItemtype($this->input['itemtype']))
                 && $item->getFromDB($this->input['items_id'])
             ) {
-                // "One write is enough": edit right on the item, or document CREATE + view
-                // (document entity still enforced by parent::canCreateItem()).
-                return $item->canAddItem('Document')
-                    || (self::canAttachToItem($item) && parent::canCreateItem());
+                // canAddItem() holds the "one write is enough" rule; parent::canCreateItem()
+                // still enforces the document's own entity.
+                return $item->canAddItem('Document') && parent::canCreateItem();
             } else {
                 unset($this->input['itemtype'], $this->input['items_id']);
             }

--- a/src/Document.php
+++ b/src/Document.php
@@ -134,6 +134,16 @@ class Document extends CommonDBTM implements TreeBrowseInterface
               || Session::haveRight('followup', ITILFollowup::ADDMY));
     }
 
+    /**
+     * Can the current user attach a document to $item?
+     * True when they can edit the item, or hold the document CREATE right while being able to view it.
+     */
+    public static function canAttachToItem(CommonDBTM $item): bool
+    {
+        return $item->canAddItem('Document')
+            || (Session::haveRight(self::$rightname, CREATE) && $item->can($item->getID(), READ));
+    }
+
     public function canCreateItem(): bool
     {
         if (isset($this->input['itemtype'], $this->input['items_id'])) {
@@ -141,10 +151,10 @@ class Document extends CommonDBTM implements TreeBrowseInterface
                 ($item = getItemForItemtype($this->input['itemtype']))
                 && $item->getFromDB($this->input['items_id'])
             ) {
-                // "One write is enough": allow if user can edit the linked item, or may
-                // create the document itself while being able to view that item.
+                // "One write is enough": edit right on the item, or document CREATE + view
+                // (document entity still enforced by parent::canCreateItem()).
                 return $item->canAddItem('Document')
-                    || (self::canCreate() && $item->can($this->input['items_id'], READ) && parent::canCreateItem());
+                    || (self::canAttachToItem($item) && parent::canCreateItem());
             } else {
                 unset($this->input['itemtype'], $this->input['items_id']);
             }

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -561,9 +561,8 @@ TWIG, $twig_params);
         $used       = array_keys($used_found);
         $used       = array_combine($used, $used);
 
-        // Only offer the add form when the submit will actually pass (see Document::canCreateItem()).
         if (
-            Document::canAttachToItem($item)
+            $item->canAddItem('Document')
             && $withtemplate < 2
         ) {
             // Restrict entity for knowbase
@@ -571,8 +570,7 @@ TWIG, $twig_params);
             $entity   = $_SESSION["glpiactive_entity"];
 
             if ($item->isEntityAssign()) {
-                // Create the document in the item's entity when the user may write there,
-                // otherwise in their own active entity (the link still exposes it on the item).
+                // Item's entity when the user may write there, otherwise their active entity.
                 if ($item->getEntityID() >= 0 && Session::haveAccessToEntity($item->getEntityID())) {
                     $entity = $item->getEntityID();
                 }
@@ -624,8 +622,7 @@ TWIG, $twig_params);
     {
         global $DB;
 
-        // Whoever may attach a document may also detach it.
-        $canedit = Document::canAttachToItem($item) && Document::canView();
+        $canedit = $item->canAddItem('Document') && Document::canView();
 
         $columns = [
             'name'      => __('Name'),

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -561,8 +561,9 @@ TWIG, $twig_params);
         $used       = array_keys($used_found);
         $used       = array_combine($used, $used);
 
+        // Show the add form when user can edit the item or create documents; relation rights are enforced on submit.
         if (
-            $item->canAddItem('Document')
+            ($item->canAddItem('Document') || Document::canCreate())
             && $withtemplate < 2
         ) {
             // Restrict entity for knowbase

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -561,9 +561,9 @@ TWIG, $twig_params);
         $used       = array_keys($used_found);
         $used       = array_combine($used, $used);
 
-        // Show the add form when user can edit the item or create documents; relation rights are enforced on submit.
+        // Only offer the add form when the submit will actually pass (see Document::canCreateItem()).
         if (
-            ($item->canAddItem('Document') || Document::canCreate())
+            Document::canAttachToItem($item)
             && $withtemplate < 2
         ) {
             // Restrict entity for knowbase
@@ -571,8 +571,9 @@ TWIG, $twig_params);
             $entity   = $_SESSION["glpiactive_entity"];
 
             if ($item->isEntityAssign()) {
-                // Case of personal items : entity = -1 : create on active entity (Reminder case))
-                if ($item->getEntityID() >= 0) {
+                // Create the document in the item's entity when the user may write there,
+                // otherwise in their own active entity (the link still exposes it on the item).
+                if ($item->getEntityID() >= 0 && Session::haveAccessToEntity($item->getEntityID())) {
                     $entity = $item->getEntityID();
                 }
 
@@ -623,7 +624,8 @@ TWIG, $twig_params);
     {
         global $DB;
 
-        $canedit = $item->canAddItem('Document') && Document::canView();
+        // Whoever may attach a document may also detach it.
+        $canedit = Document::canAttachToItem($item) && Document::canView();
 
         $columns = [
             'name'      => __('Name'),

--- a/tests/functional/Document_ItemTest.php
+++ b/tests/functional/Document_ItemTest.php
@@ -313,4 +313,58 @@ class Document_ItemTest extends DbTestCase
         $this->assertContains($linked_kb->getID(), $ids);
         $this->assertNotContains($unrelated_kb->getID(), $ids);
     }
+
+    public function testCanAttachDocumentToItemUserCanOnlyView()
+    {
+        // "One write is enough": a user who can view (but not edit) an entity-assigned
+        // item and who is allowed to create documents may still attach a document to it.
+        $this->login();
+        $child_id = getItemByTypeName('Entity', '_test_child_1', true);
+        $computer = $this->createItem('Computer', ['name' => 'doc_link_computer', 'entities_id' => $child_id]);
+
+        $this->addRightToProfile('Technician', 'document', READ | CREATE | UPDATE);
+        $this->removeRightFromProfile('Technician', 'computer', CREATE | UPDATE);
+
+        $actor = $this->createItem('User', ['name' => 'doc_actor_' . mt_rand()]);
+        $this->createItem('Profile_User', [
+            'users_id'     => $actor->getID(),
+            'profiles_id'  => getItemByTypeName('Profile', 'Technician', true),
+            'entities_id'  => $child_id,
+            'is_recursive' => 0,
+        ]);
+
+        $this->login($actor->fields['name']);
+        \Session::changeProfile(getItemByTypeName('Profile', 'Technician', true));
+        $this->setEntity('_test_child_1', false);
+
+        // The item is visible but not editable for this user.
+        $this->assertTrue($computer->can($computer->getID(), READ));
+        $this->assertFalse($computer->can($computer->getID(), UPDATE));
+
+        // "Add a new file" path (front/document.form.php) is now allowed.
+        $doc = new \Document();
+        $input = [
+            'name'        => 'linked doc',
+            'itemtype'    => 'Computer',
+            'items_id'    => $computer->getID(),
+            'entities_id' => $child_id,
+        ];
+        $this->assertTrue($doc->can(-1, CREATE, $input));
+
+        // The add form is offered on the item's "Documents" tab.
+        ob_start();
+        Document_Item::showForItem($computer);
+        $html = ob_get_clean();
+        $this->assertStringContainsString('Add a document', $html);
+
+        // The document entity is still enforced: creating it outside the user's entities is refused.
+        $doc2 = new \Document();
+        $input2 = [
+            'name'        => 'linked doc 2',
+            'itemtype'    => 'Computer',
+            'items_id'    => $computer->getID(),
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ];
+        $this->assertFalse($doc2->can(-1, CREATE, $input2));
+    }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !46055
- A user who can view but not edit an item (e.g a technician in a child entity vs. a user whose recursive profile is on the parent entity) gets no add form and a permission error on the item's Documents tab - while the same link works from Documents > Associated items.
Apply the "one write is enough" rule to both entry points: attaching is allowed if the user can edit the linked item or can create documents while being able to view it (`Document::canCreateItem()` + `Document_Item::showAddFormForItem()`). The document's entity is still enforced.

Side effect: Any user with document-create rights can now attach a document to an item they can only view. The document keeps its own entity but becomes visible/downloadable through the linked item (e.g. to parent-entity admins) — consistent with tickets and assets.


