### PR TITLE
Fix - Include parameter description in OpenAPI request body schema

### DIFF
--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -737,7 +737,11 @@ EOT;
             if ($route_param->getName() === '_') {
                 continue;
             }
-            $request_body['content']['application/json']['schema']['properties'][$route_param->getName()] = $route_param->getSchema()->toArray();
+            $property_schema = $route_param->getSchema()->toArray();
+            if ($route_param->getDescription() !== '') {
+                $property_schema['description'] = $route_param->getDescription();
+            }
+            $request_body['content']['application/json']['schema']['properties'][$route_param->getName()] = $property_schema;
         }
         return $request_body;
     }

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -128,7 +128,7 @@ final class OpenAPIGenerator
      * @param array<string, mixed>|null $parent_schema
      * @return T
      */
-    private function cleanVendorExtensions(array $schema, ?string $parent_key = null, ?array $parent_schema = null): array
+    private function cleanVendorExtensions(array $schema, ?string $parent_key = null, ?array $parent_schema = null, bool $in_request_body = false): array
     {
         $to_keep = $this->getPublicVendorExtensions();
         // Recursively walk through every key of the schema
@@ -140,7 +140,7 @@ final class OpenAPIGenerator
                 unset($schema[$key]);
                 continue;
             }
-            if ($parent_key === 'properties' && $parent_schema !== null) {
+            if (!$in_request_body && $parent_key === 'properties' && $parent_schema !== null) {
                 if (!array_key_exists('x-full-schema', $parent_schema) && $key === 'id') {
                     // Implicitly set the id property as read-only but not for partials
                     $value['readOnly'] = true;
@@ -150,7 +150,7 @@ final class OpenAPIGenerator
             if (is_array($value)) {
                 // Clean the value
                 /** @phpstan-var T $value */
-                $schema[$key] = $this->cleanVendorExtensions($value, $key, $schema);
+                $schema[$key] = $this->cleanVendorExtensions($value, $key, $schema, $in_request_body || $key === 'requestBody');
             }
         }
         /** @phpstan-var T $schema */

--- a/tests/fixtures/hlapi/snapshots/2.0.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.0.0/paths.json
@@ -28939,12 +28939,13 @@
                                         "User",
                                         "Group",
                                         "Supplier"
-                                    ]
+                                    ],
+                                    "description": "The type of team member. The applicable types of members will depend on the role."
                                 },
                                 "id": {
                                     "type": "integer",
                                     "format": "int32",
-                                    "readOnly": true
+                                    "description": "The ID of the team member"
                                 },
                                 "role": {
                                     "type": "string",
@@ -28953,7 +28954,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -29094,12 +29096,13 @@
                                         "User",
                                         "Group",
                                         "Supplier"
-                                    ]
+                                    ],
+                                    "description": "The type of team member. The applicable types of members will depend on the role."
                                 },
                                 "id": {
                                     "type": "integer",
                                     "format": "int32",
-                                    "readOnly": true
+                                    "description": "The ID of the team member"
                                 },
                                 "role": {
                                     "type": "string",
@@ -29108,7 +29111,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -29249,12 +29253,13 @@
                                         "User",
                                         "Group",
                                         "Supplier"
-                                    ]
+                                    ],
+                                    "description": "The type of team member. The applicable types of members will depend on the role."
                                 },
                                 "id": {
                                     "type": "integer",
                                     "format": "int32",
-                                    "readOnly": true
+                                    "description": "The ID of the team member"
                                 },
                                 "role": {
                                     "type": "string",
@@ -29263,7 +29268,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -29370,7 +29376,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -29454,7 +29461,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -29538,7 +29546,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -30662,12 +30671,14 @@
                             "properties": {
                                 "email": {
                                     "type": "string",
-                                    "format": "string"
+                                    "format": "string",
+                                    "description": "The email address to add"
                                 },
                                 "is_default": {
                                     "type": "boolean",
                                     "format": "boolean",
-                                    "default": false
+                                    "default": false,
+                                    "description": "Whether this email address should be the default one"
                                 }
                             }
                         }

--- a/tests/fixtures/hlapi/snapshots/2.1.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.1.0/paths.json
@@ -28939,12 +28939,13 @@
                                         "User",
                                         "Group",
                                         "Supplier"
-                                    ]
+                                    ],
+                                    "description": "The type of team member. The applicable types of members will depend on the role."
                                 },
                                 "id": {
                                     "type": "integer",
                                     "format": "int32",
-                                    "readOnly": true
+                                    "description": "The ID of the team member"
                                 },
                                 "role": {
                                     "type": "string",
@@ -28953,7 +28954,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -29094,12 +29096,13 @@
                                         "User",
                                         "Group",
                                         "Supplier"
-                                    ]
+                                    ],
+                                    "description": "The type of team member. The applicable types of members will depend on the role."
                                 },
                                 "id": {
                                     "type": "integer",
                                     "format": "int32",
-                                    "readOnly": true
+                                    "description": "The ID of the team member"
                                 },
                                 "role": {
                                     "type": "string",
@@ -29108,7 +29111,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -29249,12 +29253,13 @@
                                         "User",
                                         "Group",
                                         "Supplier"
-                                    ]
+                                    ],
+                                    "description": "The type of team member. The applicable types of members will depend on the role."
                                 },
                                 "id": {
                                     "type": "integer",
                                     "format": "int32",
-                                    "readOnly": true
+                                    "description": "The ID of the team member"
                                 },
                                 "role": {
                                     "type": "string",
@@ -29263,7 +29268,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -29370,7 +29376,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -29454,7 +29461,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -29538,7 +29546,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -30662,12 +30671,14 @@
                             "properties": {
                                 "email": {
                                     "type": "string",
-                                    "format": "string"
+                                    "format": "string",
+                                    "description": "The email address to add"
                                 },
                                 "is_default": {
                                     "type": "boolean",
                                     "format": "boolean",
-                                    "default": false
+                                    "default": false,
+                                    "description": "Whether this email address should be the default one"
                                 }
                             }
                         }

--- a/tests/fixtures/hlapi/snapshots/2.2.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.2.0/paths.json
@@ -32890,12 +32890,13 @@
                                         "User",
                                         "Group",
                                         "Supplier"
-                                    ]
+                                    ],
+                                    "description": "The type of team member. The applicable types of members will depend on the role."
                                 },
                                 "id": {
                                     "type": "integer",
                                     "format": "int32",
-                                    "readOnly": true
+                                    "description": "The ID of the team member"
                                 },
                                 "role": {
                                     "type": "string",
@@ -32904,7 +32905,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -33045,12 +33047,13 @@
                                         "User",
                                         "Group",
                                         "Supplier"
-                                    ]
+                                    ],
+                                    "description": "The type of team member. The applicable types of members will depend on the role."
                                 },
                                 "id": {
                                     "type": "integer",
                                     "format": "int32",
-                                    "readOnly": true
+                                    "description": "The ID of the team member"
                                 },
                                 "role": {
                                     "type": "string",
@@ -33059,7 +33062,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -33200,12 +33204,13 @@
                                         "User",
                                         "Group",
                                         "Supplier"
-                                    ]
+                                    ],
+                                    "description": "The type of team member. The applicable types of members will depend on the role."
                                 },
                                 "id": {
                                     "type": "integer",
                                     "format": "int32",
-                                    "readOnly": true
+                                    "description": "The ID of the team member"
                                 },
                                 "role": {
                                     "type": "string",
@@ -33214,7 +33219,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -33321,7 +33327,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -33405,7 +33412,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -33489,7 +33497,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -34613,12 +34622,14 @@
                             "properties": {
                                 "email": {
                                     "type": "string",
-                                    "format": "string"
+                                    "format": "string",
+                                    "description": "The email address to add"
                                 },
                                 "is_default": {
                                     "type": "boolean",
                                     "format": "boolean",
-                                    "default": false
+                                    "default": false,
+                                    "description": "Whether this email address should be the default one"
                                 }
                             }
                         }

--- a/tests/fixtures/hlapi/snapshots/2.3.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.3.0/paths.json
@@ -56947,12 +56947,13 @@
                                         "User",
                                         "Group",
                                         "Supplier"
-                                    ]
+                                    ],
+                                    "description": "The type of team member. The applicable types of members will depend on the role."
                                 },
                                 "id": {
                                     "type": "integer",
                                     "format": "int32",
-                                    "readOnly": true
+                                    "description": "The ID of the team member"
                                 },
                                 "role": {
                                     "type": "string",
@@ -56961,7 +56962,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -57102,12 +57104,13 @@
                                         "User",
                                         "Group",
                                         "Supplier"
-                                    ]
+                                    ],
+                                    "description": "The type of team member. The applicable types of members will depend on the role."
                                 },
                                 "id": {
                                     "type": "integer",
                                     "format": "int32",
-                                    "readOnly": true
+                                    "description": "The ID of the team member"
                                 },
                                 "role": {
                                     "type": "string",
@@ -57116,7 +57119,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -57257,12 +57261,13 @@
                                         "User",
                                         "Group",
                                         "Supplier"
-                                    ]
+                                    ],
+                                    "description": "The type of team member. The applicable types of members will depend on the role."
                                 },
                                 "id": {
                                     "type": "integer",
                                     "format": "int32",
-                                    "readOnly": true
+                                    "description": "The ID of the team member"
                                 },
                                 "role": {
                                     "type": "string",
@@ -57271,7 +57276,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -57378,7 +57384,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -57462,7 +57469,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -57546,7 +57554,8 @@
                                         "requester",
                                         "assigned",
                                         "observer"
-                                    ]
+                                    ],
+                                    "description": "The role of the team member"
                                 }
                             }
                         }
@@ -60659,12 +60668,14 @@
                             "properties": {
                                 "email": {
                                     "type": "string",
-                                    "format": "string"
+                                    "format": "string",
+                                    "description": "The email address to add"
                                 },
                                 "is_default": {
                                     "type": "boolean",
                                     "format": "boolean",
-                                    "default": false
+                                    "default": false,
+                                    "description": "Whether this email address should be the default one"
                                 }
                             }
                         }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes 46074
- Here is a brief description of what this PR does

`OpenAPIGenerator::getRequestBodySchema()` built each request body property from the parameter's schema only, dropping the parameter's `description`. As a result, body parameters (e.g. `type`, `id`, `role` on `POST /Assistance/Ticket/{id}/TeamMember`) appeared in `/api.php/doc.json` with no explanation of what they represent, even
though the description was already defined in the route's PHP attributes. Path and query parameters were not affected, since `getPathParameterSchema()` already included the description.

### Change
Include the parameter's `description` in each generated request body property, matching the existing behavior for path/query parameters.

## Screenshots (if appropriate):

### Before : 

<img width="383" height="501" alt="image" src="https://github.com/user-attachments/assets/44574b83-5036-4d9d-82e4-0b84e129f52a" />

### After :
<img width="975" height="547" alt="image" src="https://github.com/user-attachments/assets/56424f18-e4e5-494d-b3cd-655284e99ea5" />

