### PR TITLE
Fix missing translation dates during KB migration

### DIFF
--- a/install/migrations/update_11.0.x_to_12.0.0/knowbaseitemcategory_to_article.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/knowbaseitemcategory_to_article.php
@@ -75,11 +75,15 @@ if ($DB->tableExists($cat_table)) {
             if (!isset($cat_to_article[(int) $tr['items_id']])) {
                 continue;
             }
+            $now = date('Y-m-d H:i:s');
+
             $DB->insert('glpi_knowbaseitemtranslations', [
                 'knowbaseitems_id' => $cat_to_article[(int) $tr['items_id']],
                 'language'         => $tr['language'],
                 'name'             => $tr['value'],
                 'answer'           => '',
+                'date_creation'    => $now,
+                'date_mod'         => $now,
             ]);
         }
         $DB->delete('glpi_dropdowntranslations', ['itemtype' => 'KnowbaseItemCategory']);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #25191
- During the GLPI 11 to GLPI 12 migration, Knowledge Base category translations are migrated to `glpi_knowbaseitemtranslations`.
- These migrated translations were missing `date_creation` and `date_mod`, which could result in `NULL` values.
- When the article history was displayed, `HistoryBuilder` could then fail because `date_mod` was expected to be a string.
- This PR sets both `date_creation` and `date_mod` when migrating Knowledge Base category translations.

## Testing

- `vendor/bin/phpunit tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php`
- Result: 39 tests, 1705 assertions, OK

## Screenshots

Not applicable.