### PR TITLE
Fix KB history author regex

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -10316,12 +10316,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Kernel/Listener/RequestListener/PluginsRouterListener.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Offset 1 might not exist on array\\{\\}\\|array\\{non\\-empty\\-string, numeric\\-string\\}\\.$#',
-	'identifier' => 'offsetAccess.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Knowbase/History/LogEvent.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$level of method Monolog\\\\Handler\\\\StreamHandler\\:\\:__construct\\(\\) expects 100\\|200\\|250\\|300\\|400\\|500\\|550\\|600\\|\'ALERT\'\\|\'alert\'\\|\'CRITICAL\'\\|\'critical\'\\|\'DEBUG\'\\|\'debug\'\\|\'EMERGENCY\'\\|\'emergency\'\\|\'ERROR\'\\|\'error\'\\|\'INFO\'\\|\'info\'\\|\'NOTICE\'\\|\'notice\'\\|\'WARNING\'\\|\'warning\'\\|Monolog\\\\Level, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/src/Glpi/Knowbase/History/LogEvent.php
+++ b/src/Glpi/Knowbase/History/LogEvent.php
@@ -35,6 +35,7 @@
 namespace Glpi\Knowbase\History;
 
 use Override;
+use Safe\Exceptions\PcreException;
 
 use function Safe\preg_match;
 
@@ -70,8 +71,18 @@ class LogEvent implements HistoryEventInterface
     #[Override]
     public function getAuthor(): int
     {
-        preg_match("/.*(\d+)/", $this->author, $matches);
-        return (int) $matches[1];
+        // Try to get the user ID from the raw text entry.
+        // Not as easy as it seems, see LogEventTest::authorProvider() for all cases to cover.
+        try {
+            preg_match('/.*[(\x{FF08}]\s*([0-9]+)\s*[)\x{FF09}]/us', $this->author, $matches);
+        } catch (PcreException $e) {
+            // The /u flag can fail if the content is not valid UTF-8.
+            // Prevent an unlikely failure by returning 0.
+            // A warning will still be emitted here.
+            return 0;
+        }
+
+        return (int) ($matches[1] ?? 0);
     }
 
     public function getNewValue(): ?string

--- a/tests/functional/Glpi/Knowbase/History/LogEventTest.php
+++ b/tests/functional/Glpi/Knowbase/History/LogEventTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\unit\Glpi\Knowbase\History;
+
+use Glpi\Knowbase\History\LogEvent;
+use Glpi\Tests\GLPITestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class LogEventTest extends GLPITestCase
+{
+    public static function authorProvider(): iterable
+    {
+        yield 'a one digit id' => ['glpi (2)', 2];
+        yield 'a multiple digit id' => ['user (123)', 123];
+        yield 'a name that holds digits' => ['Agent 007 (42)', 42];
+        yield 'a name that holds parentheses' => ['Dupont (Ltd 3) Jean (77)', 77];
+        yield 'an unknown user' => ['Unknown user', 0];
+        yield 'a cron task' => ['mycrontask', 0];
+        yield 'no user at all' => ['', 0];
+
+        // Limitation: for languages that put the impersonator at the end,
+        // we get the wrong id because we target the last number found.
+        // This is a safety because taking the first number would fail if the
+        // user name contains a number, e.g an user named "John (2) smith".
+        // We would target 2 instead of his real ID.
+        // By taking the last number, we are sure it is not part of any name.
+        yield 'an impersonated action' => ['Smith John (5) impersonated by Doe Jane (2)', 2];
+
+        // Used by locales/zh_CN.po
+        yield 'full-width parentheses' => ['test （5）', 5];
+
+        // Used by locales/id_ID.po
+        yield 'with space at the start' => ['test ( 5)', 5];
+        yield 'with space at the end' => ['test (5 )', 5];
+
+        // Used by locales/mn_MN.po
+        yield 'with no spaces before' => ['test(5)', 5];
+    }
+
+    #[DataProvider('authorProvider')]
+    public function testGetAuthorReadsTheIdFromTheLogName(string $author, int $expected): void
+    {
+        $event = new LogEvent(
+            label: 'Permissions updated',
+            description: 'Access granted to Root entity by',
+            date: '2026-01-15 11:00:00',
+            author: $author,
+        );
+
+        $this->assertSame($expected, $event->getAuthor());
+    }
+}


### PR DESCRIPTION
The regex was only working for single digits ids like `glpi (2)`.
Longer numbers such as `test (231)` would return only the last digit instead of the full number.

While fixing this case, I've found others edge cases to fix. See the provider for all details.

There was also a limitation regarding impersonated users that we can't really fix. This is probably not a big deal as impersonation is mostly a debug feature and shouldn't be used to edit KB items regularly. 