### PR TITLE
fix(forms): compare tree dropdown answers using their complete name

### DIFF
--- a/src/Glpi/Form/Condition/ConditionHandler/ItemAsTextConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/ItemAsTextConditionHandler.php
@@ -83,7 +83,7 @@ final class ItemAsTextConditionHandler implements ConditionHandlerInterface
         if (!$item) {
             return false;
         }
-        $a = $item->getName();
+        $a = $item->getName(['complete' => true]);
 
         // Normalize values
         $a = strtolower(strval($a));

--- a/tests/functional/Glpi/Form/Condition/ConditionHandler/ItemAsTextConditionHandlerTest.php
+++ b/tests/functional/Glpi/Form/Condition/ConditionHandler/ItemAsTextConditionHandlerTest.php
@@ -41,6 +41,7 @@ use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
 use Glpi\Form\QuestionType\QuestionTypeItemDropdownExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Glpi\Tests\AbstractConditionHandlerTest;
+use Location;
 use Override;
 use SoftwareCategory;
 
@@ -65,6 +66,41 @@ final class ItemAsTextConditionHandlerTest extends AbstractConditionHandlerTest
             default:
                 throw new \InvalidArgumentException("Unsupported question type: $question_type");
         }
+    }
+
+    public function testComparisonIsDoneOnCompleteNameForTreeDropdowns(): void
+    {
+        $this->login();
+
+        // Arrange: create a location with a parent
+        $parent = $this->createItem(Location::class, ['name' => 'Parent location']);
+        $child  = $this->createItem(Location::class, [
+            'name'         => 'Child location',
+            'locations_id' => $parent->getID(),
+        ]);
+
+        // Act: compare the child with its parent name
+        $handler = new ItemAsTextConditionHandler(Location::class);
+        $answer  = ['itemtype' => Location::class, 'items_id' => $child->getID()];
+
+        // Assert: the complete name of the child contains the parent name
+        $this->assertTrue($handler->applyValueOperator(
+            $answer,
+            ValueOperator::CONTAINS,
+            'Parent location > Child location',
+        ));
+
+        // Assert: the parent name is part of the child complete name
+        $this->assertTrue($handler->applyValueOperator(
+            $answer,
+            ValueOperator::CONTAINS,
+            'Parent location',
+        ));
+        $this->assertFalse($handler->applyValueOperator(
+            $answer,
+            ValueOperator::NOT_CONTAINS,
+            'Parent location',
+        ));
     }
 
     #[Override]


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !44202

Form visibility conditions using the `contains` / `does not contain` operators on an item question compared the value against the item's own name. For tree dropdowns (`CommonTreeDropdown`), the form displays the complete name (`Parent > Child`), so a condition written against what the user actually sees never matched.

Note: as a side effect, `contains <parent name>` now also matches child items, which is the expected behaviour when matching on the displayed value.


