### PR TITLE
fix(forms): apply conditions on checkbox questions filled with a default value

### DIFF
--- a/src/Glpi/Form/Condition/ConditionHandler/MultipleChoiceFromValuesConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/MultipleChoiceFromValuesConditionHandler.php
@@ -78,7 +78,7 @@ final class MultipleChoiceFromValuesConditionHandler implements
         // During form rendering, applyValueOperator is called to compute items
         // visibility using the question default value, which is stored as a
         // comma separated list of options.
-        if (is_string($a)) {
+        if (is_string($a) && $a !== '') {
             $a = explode(',', $a);
         }
 

--- a/src/Glpi/Form/Condition/ConditionHandler/MultipleChoiceFromValuesConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/MultipleChoiceFromValuesConditionHandler.php
@@ -75,6 +75,13 @@ final class MultipleChoiceFromValuesConditionHandler implements
         ValueOperator $operator,
         mixed $b,
     ): bool {
+        // During form rendering, applyValueOperator is called to compute items
+        // visibility using the question default value, which is stored as a
+        // comma separated list of options.
+        if (is_string($a)) {
+            $a = explode(',', $a);
+        }
+
         return $this->applyArrayValueOperator($a, $operator, $b);
     }
 

--- a/tests/e2e/specs/Form/conditions_applied.spec.ts
+++ b/tests/e2e/specs/Form/conditions_applied.spec.ts
@@ -180,6 +180,32 @@ test(`Conditions are applied on comments`, async ({
     await expect(page.getByRole('heading', { name: 'My comment that is always visible' })).toBeVisible();
 });
 
+test(`Conditions are applied on comments using a checkbox checked by default`, async ({
+    page,
+    profile,
+    formImporter,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const info = await formImporter.importForm("comment-hidden-if-default-checked-checkbox.json");
+    const preview = new FormPreviewPage(page);
+    await preview.goto(info.getId());
+
+    const comment = page.getByRole('heading', { name: 'My comment that is hidden if the checkbox is checked' });
+    const option = page.getByRole('checkbox', { name: 'Option 1' });
+
+    // Default state: the checkbox is checked by default, the comment must be hidden
+    await expect(option).toBeChecked();
+    await expect(comment).toBeHidden();
+
+    // Uncheck the option: the comment becomes visible
+    await option.uncheck();
+    await expect(comment).toBeVisible();
+
+    // Check the option again: the comment is hidden again
+    await option.check();
+    await expect(comment).toBeHidden();
+});
+
 test(`Conditions are applied on sections`, async ({
     page,
     profile,

--- a/tests/fixtures/forms/comment-hidden-if-default-checked-checkbox.json
+++ b/tests/fixtures/forms/comment-hidden-if-default-checked-checkbox.json
@@ -1,0 +1,109 @@
+{
+    "version": 1,
+    "forms": [
+        {
+            "id": 1,
+            "uuid": "e1a2b3c4-d5e6-7890-abcd-ef1234567891",
+            "name": "Comment hidden if default checked checkbox",
+            "header": null,
+            "description": null,
+            "entity_name": "Root entity",
+            "is_recursive": true,
+            "is_active": true,
+            "submit_button_visibility_strategy": "always_visible",
+            "illustration": "",
+            "submit_button_conditions": [],
+            "sections": [
+                {
+                    "id": 1,
+                    "uuid": "e1b2c3d4-0001-0001-0001-000000000001",
+                    "name": "First section",
+                    "description": null,
+                    "rank": 0,
+                    "visibility_strategy": "always_visible",
+                    "conditions": []
+                }
+            ],
+            "comments": [
+                {
+                    "id": 1,
+                    "uuid": "e1b2c3d4-0001-0001-0001-000000000030",
+                    "name": "My comment that is hidden if the checkbox is checked",
+                    "description": "",
+                    "vertical_rank": 1,
+                    "horizontal_rank": null,
+                    "section_id": 1,
+                    "visibility_strategy": "hidden_if",
+                    "conditions": [
+                        {
+                            "item_uuid": "e1b2c3d4-0001-0001-0001-000000000010",
+                            "item_type": "question",
+                            "value_operator": "equals",
+                            "logic_operator": "and",
+                            "value": [1]
+                        }
+                    ]
+                }
+            ],
+            "questions": [
+                {
+                    "id": 1,
+                    "uuid": "e1b2c3d4-0001-0001-0001-000000000010",
+                    "name": "My checkbox question used as a criteria",
+                    "type": "Glpi\\Form\\QuestionType\\QuestionTypeCheckbox",
+                    "is_mandatory": false,
+                    "vertical_rank": 0,
+                    "horizontal_rank": null,
+                    "description": "",
+                    "default_value": "1",
+                    "extra_data": {"options": {"1": "Option 1", "2": "Option 2"}},
+                    "section_id": 1,
+                    "visibility_strategy": "always_visible",
+                    "validation_strategy": "no_validation",
+                    "conditions": [],
+                    "validation_conditions": []
+                }
+            ],
+            "policies": [
+                {
+                    "strategy": "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                    "config": {
+                        "user_ids": [
+                            "all"
+                        ],
+                        "group_ids": [],
+                        "profile_ids": []
+                    },
+                    "is_active": true
+                },
+                {
+                    "strategy": "Glpi\\Form\\AccessControl\\ControlType\\DirectAccess",
+                    "config": {
+                        "token": "kR3vN8sPq1wZxY6tL2bH9cJ4mD7fA0gU5eS1iO2p",
+                        "allow_unauthenticated": false
+                    },
+                    "is_active": false
+                }
+            ],
+            "destinations": [
+                {
+                    "id": 1,
+                    "itemtype": "Glpi\\Form\\Destination\\FormDestinationTicket",
+                    "name": "Ticket",
+                    "config": [],
+                    "creation_strategy": "",
+                    "conditions": []
+                }
+            ],
+            "translations": [],
+            "data_requirements": [
+                {
+                    "itemtype": "Entity",
+                    "name": "Root entity"
+                }
+            ],
+            "custom_types_requirements": [],
+            "plugin_requirements": []
+        }
+    ]
+}

--- a/tests/functional/Glpi/Form/Condition/ConditionHandler/MultipleChoiceFromValuesConditionHandlerTest.php
+++ b/tests/functional/Glpi/Form/Condition/ConditionHandler/MultipleChoiceFromValuesConditionHandlerTest.php
@@ -327,5 +327,74 @@ final class MultipleChoiceFromValuesConditionHandlerTest extends AbstractConditi
             'expected_result'     => false,
             'question_extra_data' => $extra_data,
         ];
+
+        // Default values are supplied by `EngineInput::fromForm()` as the raw
+        // `default_value` database column, i.e. a comma separated list of
+        // option uuids. An empty string means "no option checked by default",
+        // which must behave exactly like an unanswered question.
+        yield "Equals check with a default value for $type" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::EQUALS,
+            'condition_value'     => ["option_a", "option_c"],
+            'submitted_answer'    => "option_a,option_c",
+            'expected_result'     => true,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Equals check with an empty default value for $type" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::EQUALS,
+            'condition_value'     => ["option_c"],
+            'submitted_answer'    => "",
+            'expected_result'     => false,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Not equals check with a default value for $type" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::NOT_EQUALS,
+            'condition_value'     => ["option_a"],
+            'submitted_answer'    => "option_a,option_c",
+            'expected_result'     => true,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Not equals check with an empty default value for $type" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::NOT_EQUALS,
+            'condition_value'     => ["option_c"],
+            'submitted_answer'    => "",
+            'expected_result'     => false,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Contains check with a default value for $type" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::CONTAINS,
+            'condition_value'     => ["option_c"],
+            'submitted_answer'    => "option_a,option_c",
+            'expected_result'     => true,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Contains check with an empty default value for $type" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::CONTAINS,
+            'condition_value'     => ["option_c"],
+            'submitted_answer'    => "",
+            'expected_result'     => false,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Not contains check with a default value for $type" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::NOT_CONTAINS,
+            'condition_value'     => ["option_b"],
+            'submitted_answer'    => "option_a,option_c",
+            'expected_result'     => true,
+            'question_extra_data' => $extra_data,
+        ];
+        yield "Not contains check with an empty default value for $type" => [
+            'question_type'       => $type,
+            'condition_operator'  => ValueOperator::NOT_CONTAINS,
+            'condition_value'     => ["option_c"],
+            'submitted_answer'    => "",
+            'expected_result'     => false,
+            'question_extra_data' => $extra_data,
+        ];
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !44202

When a checkbox question is used as a condition criteria and has a default value, the condition was evaluated as false on the initial rendering: the linked question / section / comment stayed in its default state until the user unchecked and rechecked an option.