### PR TITLE
Remove deprecated password encryption fallback check

### DIFF
--- a/phpunit/functional/AuthTest.php
+++ b/phpunit/functional/AuthTest.php
@@ -183,26 +183,6 @@ class AuthTest extends DbTestCase
         $auth = new \Auth();
         $_SESSION["glpiextauth"] = false; //required to prevent undefined array index
 
-        //create a user - with a md5 password
-        $user = $this->createItem(User::class, ['name' => 'MD5 Passwd test', 'password' => md5('dapass')]);
-        $user->getFromDB($user->getID());
-        $this->assertSame('6902587896395f6b27f5aa550f69008a', $user->fields['password']);
-
-        //log in should update password to default PHP (BCRYPT currently)
-        $this->assertTrue($auth->login('MD5 Passwd test', 'dapass'));
-        $user->getFromDB($user->getID());
-        $this->assertStringStartsWith('$2y$', $user->fields['password']);
-
-        //create a user - with a sha1 password
-        $user = $this->createItem(User::class, ['name' => 'SHA1 Passwd test', 'password' => sha1('dapass')]);
-        $user->getFromDB($user->getID());
-        $this->assertSame('a5c805c5e55c0ce85e515e34ff9ae0b6a94d142a', $user->fields['password']);
-
-        //log in should update password to default PHP (BCRYPT currently)
-        $this->assertTrue($auth->login('SHA1 Passwd test', 'dapass'));
-        $user->getFromDB($user->getID());
-        $this->assertStringStartsWith('$2y$', $user->fields['password']);
-
         //create a user - with a low cost password
         $user = $this->createItem(User::class, ['name' => 'BCRYPT low cost Passwd test', 'password' => password_hash('dapass', PASSWORD_DEFAULT, ['cost' => 5])]);
         $user->getFromDB($user->getID());
@@ -214,6 +194,73 @@ class AuthTest extends DbTestCase
         $new_cost = null;
         preg_match('/\$2y\$(\d+)\$.+/', $user->fields['password'], $new_cost);
         $this->assertGreaterThan(5, (int) $new_cost[1]);
+    }
+
+    public function testCheckPasswordWithCurrentHash(): void
+    {
+        $hash = \Auth::getPasswordHash('mypassword');
+
+        $this->assertTrue(\Auth::checkPassword('mypassword', $hash));
+        $this->assertFalse(\Auth::checkPassword('wrongpassword', $hash));
+    }
+
+    public function testCheckPasswordNeverValidatesLegacyHashes(): void
+    {
+        $this->assertFalse(\Auth::checkPassword('mypassword', md5('mypassword')));
+        $this->assertFalse(\Auth::checkPassword('mypassword', sha1('mypassword')));
+    }
+
+    public static function outdatedPasswordHashProvider(): iterable
+    {
+        // Legacy
+        yield 'md5' => [md5('mypassword')];
+        yield 'sha1' => [sha1('mypassword')];
+        // Legacy salted sha1
+        yield 'salted sha1' => ['abcdefgh' . sha1('abcdefgh' . 'mypassword')];
+    }
+
+    /**
+     * A user password has never been migrated from the 0.85 hashing scheme
+     * @dataProvider outdatedPasswordHashProvider
+     */
+    public function testLoginWithOutdatedPasswordHashIsRejected(string $hash): void
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $this->login();
+
+        $username = 'test_outdated_password_' . mt_rand();
+        $user = new User();
+        $user_id = (int) $user->add([
+            'name'         => $username,
+            'password'     => 'mypassword',
+            'password2'    => 'mypassword',
+            '_profiles_id' => 1,
+        ]);
+        $this->assertGreaterThan(0, $user_id);
+
+        // Write the legacy hash directly in DB, as User::update() would rehash it.
+        $this->assertTrue(
+            $DB->update(
+                User::getTable(),
+                ['password' => $hash],
+                ['id' => $user_id]
+            )
+        );
+
+        $this->logOut();
+
+        $auth = new \Auth();
+        $this->assertFalse($auth->login($username, 'mypassword', true));
+        $this->assertContains(
+            __('For security reasons, your password has expired. Please contact your administrator to reset it.'),
+            $auth->getErrors()
+        );
+
+        // The stored hash must remain untouched (not silently rehashed).
+        $this->assertTrue($user->getFromDB($user_id));
+        $this->assertSame($hash, $user->fields['password']);
     }
 
     public function testRememberMeLastLogin(): void

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -330,7 +330,7 @@ class Auth extends CommonGLPI
      *
      * @return boolean
      */
-    public static function passwordIsOutdated(string $hash): bool
+    private static function passwordIsOutdated(string $hash): bool
     {
         $info = password_get_info($hash);
         return !isset($info['algo']) || !$info['algo'];

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -324,6 +324,19 @@ class Auth extends CommonGLPI
     }
 
     /**
+     * Password is using and old encryption method like md5 or sha1
+     *
+     * @param string $hash Hash
+     *
+     * @return boolean
+     */
+    public static function passwordIsOutdated(string $hash): bool
+    {
+        $info = password_get_info($hash);
+        return !isset($info['algo']) || !$info['algo'];
+    }
+
+    /**
      * Check is a password match the stored hash
      *
      * @since 0.85
@@ -335,16 +348,7 @@ class Auth extends CommonGLPI
      */
     public static function checkPassword($pass, $hash)
     {
-
-        $tmp = password_get_info($hash);
-
-        if (isset($tmp['algo']) && $tmp['algo']) {
-            $ok = password_verify($pass, $hash);
-        } else {
-            throw new \RuntimeException(__('For security reasons, your password has expired. Please contact your administrator to reset it.'));
-        }
-
-        return $ok;
+        return password_verify($pass, $hash);
     }
 
     /**
@@ -437,6 +441,11 @@ class Auth extends CommonGLPI
         if ($result->numrows() == 1) {
             $row = $result->current();
             $password_db = $row['password'];
+
+            if (self::passwordIsOutdated($password_db)) {
+                $this->addToError(__('For security reasons, your password has expired. Please contact your administrator to reset it.'));
+                return false;
+            }
 
             if (self::checkPassword($password, $password_db)) {
                 // Disable account if password expired

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -340,13 +340,8 @@ class Auth extends CommonGLPI
 
         if (isset($tmp['algo']) && $tmp['algo']) {
             $ok = password_verify($pass, $hash);
-        } elseif (strlen($hash) == 32) {
-            $ok = md5($pass) === $hash;
-        } elseif (strlen($hash) == 40) {
-            $ok = sha1($pass) === $hash;
         } else {
-            $salt = substr($hash, 0, 8);
-            $ok = ($salt . sha1($salt . $pass) === $hash);
+            throw new \RuntimeException(__('For security reasons, your password has expired. Please contact your administrator to reset it.'));
         }
 
         return $ok;


### PR DESCRIPTION
Remove old password encryption fallback.

Display an error message on login page:

- GLPI 10 
  <img width="493" height="303" alt="image" src="https://github.com/user-attachments/assets/e241dd14-5421-42d0-b7bf-a3d0e5119cad" />

- GLPI 11
  <img width="493" height="303" alt="image" src="https://github.com/user-attachments/assets/c14b356b-4298-4411-85bd-7ce111cf8fcc" />
