### PR TITLE
fix(rules): log auto-deactivation under the real rule type

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -3203,7 +3203,14 @@ TWIG, ['label' => $this->getTitle()]);
 
                 foreach ($iterator as $data) {
                     $input['id'] = $data[$fieldid];
-                    $ruleitem->update($input);
+                    // Update the rule through its concrete class, otherwise the history entry
+                    // would be attached to the `Rule` itemtype and would therefore not be
+                    // visible in the history tab of the rule.
+                    $updated_item = $ruleitem;
+                    if ($ruleitem::getTable() === self::getTable()) {
+                        $updated_item = self::getRuleObjectByID($data[$fieldid]) ?? $ruleitem;
+                    }
+                    $updated_item->update($input);
                 }
                 Session::addMessageAfterRedirect(
                     __s('Rules using the object have been disabled.'),

--- a/tests/functional/RuleTest.php
+++ b/tests/functional/RuleTest.php
@@ -557,6 +557,65 @@ class RuleTest extends DbTestCase
         $this->assertFalse($action->getFromDB($action_1));
     }
 
+    public function testCleanForItemCriteriaLogsUnderConcreteRuleType()
+    {
+        $collector     = new \MailCollector();
+        $collectors_id = $collector->add([
+            'name'        => 'Test collector',
+            'host'        => '{imap.example.org/imap/ssl}INBOX',
+            'login'       => 'test',
+            'passwd'      => 'test',
+            'is_active'   => 1,
+            'entities_id' => 0,
+        ]);
+        $this->assertGreaterThan(0, (int) $collectors_id);
+
+        $rule     = new \RuleMailCollector();
+        $rules_id = $rule->add([
+            'name'        => 'Test rule',
+            'sub_type'    => 'RuleMailCollector',
+            'match'       => Rule::AND_MATCHING,
+            'is_active'   => 1,
+            'entities_id' => 0,
+            'condition'   => 0,
+            'description' => '',
+        ]);
+        $this->assertGreaterThan(0, (int) $rules_id);
+
+        $criteria = new \RuleCriteria();
+        $this->assertGreaterThan(0, (int) $criteria->add([
+            'rules_id'  => $rules_id,
+            'criteria'  => 'mailcollector',
+            'condition' => Rule::PATTERN_IS,
+            'pattern'   => $collectors_id,
+        ]));
+
+        // Purging the collector disables the rules using it as a criterion.
+        $this->assertTrue($collector->delete(['id' => $collectors_id], true));
+
+        $this->assertTrue($rule->getFromDB($rules_id));
+        $this->assertSame(0, (int) $rule->fields['is_active']);
+
+        // The deactivation must be traceable from the rule history tab, which only
+        // displays entries logged under the concrete rule type.
+        $is_active_so = 8;
+        $this->assertSame(
+            1,
+            countElementsInTable(
+                'glpi_logs',
+                [
+                    'itemtype'         => 'RuleMailCollector',
+                    'items_id'         => $rules_id,
+                    'id_search_option' => $is_active_so,
+                ]
+            )
+        );
+        $this->assertSame(
+            0,
+            countElementsInTable('glpi_logs', ['itemtype' => 'Rule', 'items_id' => $rules_id])
+        );
+    }
+
     public function testPrepareInputForAdd()
     {
         $rule     = new \RuleRight();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

- !46231

When you purge an item used by a rule, GLPI automatically deactivates that rule. The change is logged under the wrong itemtype, so it never shows up in the rule history tab: the rule looks like it was deactivated by nobody.

This PR logs it under the right itemtype so the deactivation is visible, with its author and date.

Old entries are not migrated.
