### PR TITLE
Icon picker: allow "no illustration" value only for the KB

### DIFF
--- a/js/modules/IllustrationPicker/Controller.js
+++ b/js/modules/IllustrationPicker/Controller.js
@@ -430,9 +430,10 @@ export class GlpiIllustrationPickerController
     {
         const url = `${CFG_GLPI.root_doc}/UI/Illustration/Search`;
         const url_params = new URLSearchParams({
-            filter   : filter,
-            page     : page,
-            page_size: this.#getPageSizeValue(),
+            filter     : filter,
+            page       : page,
+            page_size  : this.#getPageSizeValue(),
+            allow_empty: this.#getAllowEmptyValueUrlParameter(),
         });
         const response = await fetch(`${url}?${url_params}`);
 
@@ -484,6 +485,16 @@ export class GlpiIllustrationPickerController
     {
         return this.#container.querySelector('[data-glpi-icon-picker-page-size]')
             .dataset['glpiIconPickerPageSize']
+        ;
+    }
+
+    /**
+     * @return {string} '1' or '0' (not a boolean because it is only used as an url parameter)
+     */
+    #getAllowEmptyValueUrlParameter()
+    {
+        return this.#container.querySelector('[data-glpi-icon-picker-allow-empty]')
+            ?.dataset['glpiIconPickerAllowEmpty'] ?? '0'
         ;
     }
 

--- a/src/Glpi/Controller/UI/Illustration/SearchController.php
+++ b/src/Glpi/Controller/UI/Illustration/SearchController.php
@@ -48,17 +48,19 @@ final class SearchController extends AbstractController
     public function __invoke(Request $request): Response
     {
         // Read parameters
-        $filter    = $request->query->getString('filter', "");
-        $page      = $request->query->getInt('page', 1);
-        $page_size = $request->query->getInt('page_size', 30);
+        $filter      = $request->query->getString('filter', "");
+        $page        = $request->query->getInt('page', 1);
+        $page_size   = $request->query->getInt('page_size', 30);
+        $allow_empty = $request->query->getBoolean('allow_empty', false);
 
         // Output modal body
         return $this->render(
             'components/illustration/icon_picker_search_results.html.twig',
             [
-                'filter'    => $filter,
-                'page'      => $page,
-                'page_size' => $page_size,
+                'filter'      => $filter,
+                'page'        => $page,
+                'page_size'   => $page_size,
+                'allow_empty' => $allow_empty,
             ]
         );
     }

--- a/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
@@ -84,7 +84,7 @@ final class ExternalPageTile extends CommonDBTM implements TileInterface, Provid
     #[Override]
     public function getIllustration(): string
     {
-        return $this->fields['illustration'] ?? IllustrationManager::DEFAULT_ILLUSTRATION;
+        return ($this->fields['illustration'] ?? '') ?: IllustrationManager::DEFAULT_ILLUSTRATION;
     }
 
     #[Override]

--- a/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
@@ -108,7 +108,7 @@ final class GlpiPageTile extends CommonDBTM implements TileInterface, ProvideTra
     #[Override]
     public function getIllustration(): string
     {
-        return $this->fields['illustration'] ?? IllustrationManager::DEFAULT_ILLUSTRATION;
+        return ($this->fields['illustration'] ?? '') ?: IllustrationManager::DEFAULT_ILLUSTRATION;
     }
 
     #[Override]

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -1053,6 +1053,7 @@
     {% set options = {
         extra_css_classes: "",
         backdrop: true,
+        allow_empty: false,
     }|merge(options) %}
     {% set field %}
         {{ include('components/illustration/icon_picker.html.twig', {
@@ -1061,6 +1062,7 @@
             'size': 100,
             'preview_css_classes': "illustration-selector d-flex align-items-center card border-1 " ~ options.extra_css_classes,
             'backdrop': options.backdrop,
+            'allow_empty': options.allow_empty,
         }, with_context: false) }}
     {% endset %}
 

--- a/templates/components/illustration/icon_picker.html.twig
+++ b/templates/components/illustration/icon_picker.html.twig
@@ -42,6 +42,7 @@
  #   - backdrop: whether the modal should have a backdrop (defaults to true)
  #   - editable: whether clicking the preview opens the modal (defaults to true).
  #     Renders a <button> when true, a <div> otherwise (see setEditable()).
+ #   - allow_empty: whether the modal offers a "No illustration" value.
  #}
 
 {% set custom_icon_prefix = constant(
@@ -52,6 +53,7 @@
 {% set size = size ?? 100 %}
 {% set backdrop = backdrop ?? true %}
 {% set editable = editable ?? true %}
+{% set allow_empty = allow_empty ?? false %}
 {% set preview_css_classes = preview_css_classes ?? "illustration-selector d-flex align-items-center card border-1" %}
 {% set preview_inner_css_classes = preview_inner_css_classes ?? "card-body aspect-ratio-1" %}
 
@@ -138,6 +140,7 @@
     {{ include('components/illustration/icon_picker_modal.html.twig', {
         'id': modal_id,
         'backdrop': backdrop,
+        'allow_empty': allow_empty,
     }, with_context: false) }}
 
     <script defer type="module">

--- a/templates/components/illustration/icon_picker_modal.html.twig
+++ b/templates/components/illustration/icon_picker_modal.html.twig
@@ -30,6 +30,7 @@
  # ---------------------------------------------------------------------
  #}
 
+{% set allow_empty = allow_empty ?? false %}
 {% set rand = random() %}
 {% set upload_an_icon_pane_id = 'upload-an-icon-pane-' ~ rand %}
 {% set pick_an_icon_pane_id = 'pick-an-icon-pane-' ~ rand %}
@@ -116,6 +117,7 @@
                         'filter': '',
                         'page': 1,
                         'page_size': 30,
+                        'allow_empty': allow_empty,
                     }, with_context: false) }}
                 </div>
                 <div id="{{ upload_an_icon_pane_id }}" class="tab-pane fade" role="tabpanel" aria-labelledby="upload-an-icon-{{ rand }}">

--- a/templates/components/illustration/icon_picker_search_results.html.twig
+++ b/templates/components/illustration/icon_picker_search_results.html.twig
@@ -30,6 +30,7 @@
  # ---------------------------------------------------------------------
  #}
 
+{% set allow_empty = allow_empty ?? false %}
 {% set total_pages = (countIcons(filter) / page_size)|round(0, 'ceil') %}
 {% set icon_ids = searchIcons(filter, page, page_size) %}
 
@@ -38,10 +39,13 @@
     {# Keep track of our page size as we will need to request the same size
     when querying the server for others pages #}
     data-glpi-icon-picker-page-size="{{ page_size }}"
+    {# Same for the "No illustration" tile, which must not reappear on the
+    pages fetched by AJAX when the picker does not allow an empty value. #}
+    data-glpi-icon-picker-allow-empty="{{ allow_empty ? 1 : 0 }}"
 >
     {% if icon_ids|length %}
         <div class="row g-3 mb-4 align-items-start" role="group" aria-label="{{ __('Illustrations') }}">
-            {% if page == 1 and filter is empty %}
+            {% if allow_empty and page == 1 and filter is empty %}
                 {# Tile to clear the selection — only shown on the first page with no filter. #}
                 <button
                     type="button"

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -104,6 +104,7 @@
                         'preview_css_classes': "kb-illustration-preview d-flex align-items-center justify-content-center rounded",
                         'preview_inner_css_classes': "",
                         'editable': false,
+                        'allow_empty': true,
                     }, with_context: false) }}
                 </div>
             {% endif %}


### PR DESCRIPTION
A "no illustration" value was added to the picker for the KB:

<img width="941" height="1145" alt="image" src="https://github.com/user-attachments/assets/19ad0542-d69f-4976-a5ad-d3c6113fcf6c" />

However, others features that rely on the same picker (forms, helpdesks tiles, ...) might not want it (maybe they don't allow an empty value).

I've changed it so that the option must be enabled explicitly.