### PR TITLE
Fix Qodo automatic review command name

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -7,7 +7,7 @@ ignore_pr_authors = ["\\[bot\\]$"] # GitHub reserves the suffix for apps
 ignore_pr_labels = ["no-ai-review"]
 
 [github_app]
-pr_commands = ["/qodo_review"] # default also runs /agentic_describe
+pr_commands = ["/agentic_review"] # default also runs /agentic_describe
 
 [review_agent]
 comments_routing_preset = "custom"


### PR DESCRIPTION
/qodo_review does not exist; the review command is /agentic_review. With an unknown command as the only entry, no review was triggered.

cf #25444 