### PR TITLE
fix(kb): Correctly restrict item dropdown entities on Knowledge Base associated items

### DIFF
--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -204,6 +204,15 @@ class KnowbaseItem_Item extends CommonDBRelation
         $entity_restrict = -1;
         $checkright = true;
 
+        if ($item instanceof KnowbaseItem && isset($item->fields['entities_id'])) {
+            $is_recursive = $item->fields['is_recursive'] ?? 0;
+            if ($is_recursive) {
+                $entity_restrict = getSonsOf('glpi_entities', $item->fields['entities_id']);
+            } else {
+                $entity_restrict = $item->fields['entities_id'];
+            }
+        }
+
         return Dropdown::showSelectItemFromItemtypes([
             'items_id_name'   => $name,
             'entity_restrict' => $entity_restrict,

--- a/tests/functional/KnowbaseItem_ItemTest.php
+++ b/tests/functional/KnowbaseItem_ItemTest.php
@@ -252,6 +252,41 @@ class KnowbaseItem_ItemTest extends DbTestCase
         $name = $kb_item->getTabNameForItem($ticket3);
         $this->assertSame("Knowledge base", strip_tags($name));
     }
+
+    public function testDropdownAllTypesEntityRestrict()
+    {
+        $this->login();
+
+        $kb = new KnowbaseItem();
+
+        // 1. Test non-recursive KB article
+        $kb->getEmpty();
+        $kb->fields['entities_id'] = 123;
+        $kb->fields['is_recursive'] = 0;
+
+        ob_start();
+        KnowbaseItem_Item::dropdownAllTypes($kb, 'items_id');
+        $output = ob_get_clean();
+
+        // Ensure the dropdown ajax config contains the specific entity ID (unquoted key in JS object literal)
+        $this->assertStringContainsString('entity_restrict:123', $output, 'Dropdown should restrict to exact entity for non-recursive KB articles.');
+
+        // 2. Test recursive KB article
+        $kb->getEmpty();
+        $kb->fields['entities_id'] = 123;
+        $kb->fields['is_recursive'] = 1;
+
+        ob_start();
+        KnowbaseItem_Item::dropdownAllTypes($kb, 'items_id');
+        $output = ob_get_clean();
+
+        // For recursive KB articles, it should use getSonsOf()
+        $expected_entities = getSonsOf('glpi_entities', 123);
+        $expected_json = json_encode(array_values($expected_entities));
+
+        $this->assertStringContainsString('entity_restrict:' . $expected_json, $output, 'Dropdown should restrict to child entities for recursive KB articles.');
+    }
+
     public static function normalizeForDisplayProvider(): iterable
     {
         yield 'empty string is returned as-is' => [

--- a/tests/functional/KnowbaseItem_ItemTest.php
+++ b/tests/functional/KnowbaseItem_ItemTest.php
@@ -252,6 +252,42 @@ class KnowbaseItem_ItemTest extends DbTestCase
         $name = $kb_item->getTabNameForItem($ticket3);
         $this->assertSame("Knowledge base", strip_tags($name));
     }
+
+    public function testDropdownAllTypesEntityRestrict()
+    {
+        $this->login();
+
+        $kb = new KnowbaseItem();
+
+        // 1. Test non-recursive KB article
+        $kb->getEmpty();
+        $kb->fields['entities_id'] = 123;
+        $kb->fields['is_recursive'] = 0;
+
+        ob_start();
+        KnowbaseItem_Item::dropdownAllTypes($kb, 'items_id');
+        $output = ob_get_clean();
+
+        // Ensure the dropdown ajax config contains the specific entity ID
+        $this->assertStringContainsString('"entity_restrict":123', $output, 'Dropdown should restrict to exact entity for non-recursive KB articles.');
+
+        // 2. Test recursive KB article
+        $kb->getEmpty();
+        $kb->fields['entities_id'] = 123;
+        $kb->fields['is_recursive'] = 1;
+
+        ob_start();
+        KnowbaseItem_Item::dropdownAllTypes($kb, 'items_id');
+        $output = ob_get_clean();
+
+        // For recursive KB articles, it should use getSonsOf()
+        $expected_entities = getSonsOf('glpi_entities', 123);
+        $expected_json = json_encode(array_values($expected_entities));
+        $expected_encoded = json_encode($expected_json); // ajax JS string encodes the JSON array
+
+        $this->assertStringContainsString('"entity_restrict":' . $expected_encoded, $output, 'Dropdown should restrict to child entities for recursive KB articles.');
+    }
+
     public static function normalizeForDisplayProvider(): iterable
     {
         yield 'empty string is returned as-is' => [


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

When attempting to link an item (e.g., a Computer) to a Knowledge Base (KB) article that has the "Sub-entities" checkbox unchecked, the UI dropdown was incorrectly displaying assets from sub-entities. However, when attempting to save the correlation, a `User failed a can* method check for right 4 (CREATE)` exception would be thrown because the relation coherency logic correctly enforces entity alignment.

This PR closes #25451 by updating `KnowbaseItem_Item::dropdownAllTypes()` to dynamically assign `entity_restrict` based on the KB article's configuration, mirroring the behavior used elsewhere (like Appliances and Consumables). 

## Changes Made
- Updated `src/KnowbaseItem_Item.php` to respect the KB article's `is_recursive` setting when rendering the item dropdown.
- If the KB article is recursive, the dropdown now restricts the search scope to the article's entity and all child sub-entities (using `getSonsOf()`).
- If the KB article is not recursive, the dropdown strictly restricts the scope to the article's own entity ID.

## How to Test
1. Create or open a KB article in a parent entity (e.g., Root entity).
2. Ensure the "Sub-entities" checkbox on the KB article is **unchecked**.
3. Navigate to the "Associated items" (or Items) tab on the KB article.
4. Attempt to add a link. Notice that items located in sub-entities (e.g., Root entity > ITN) are properly filtered out and no longer selectable.
5. Alternatively, check the "Sub-entities" checkbox, go back to the "Associated items" tab, and verify that items from sub-entities are now selectable and can be saved without throwing a permissions exception.

## Screenshots (if appropriate):


