### PR TITLE
fix(ui): inverted tooltips in Select2 dropdowns

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -911,6 +911,10 @@ var templateSelection = function (selection) {
     }
     var _elt = $('<span></span>');
     _elt.html(_.escape(text));
+
+    // Fix tooltip RTL rendering issue by using First Strong Isolate
+    selection.title = '\u2068' + text + '\u2069';
+
     return _elt;
 };
 
@@ -967,6 +971,9 @@ var templateItilStatus = function(option) {
             break;
     }
 
+    // Fix tooltip RTL rendering issue by using First Strong Isolate
+    option.title = '\u2068' + option.text + '\u2069';
+
     return $(`<span><i class="itilstatus ${classes}"></i> ${_.escape(option.text)}</span>`);
 };
 
@@ -991,6 +998,9 @@ var templateValidation = function(option) {
             break;
     }
 
+    // Fix tooltip RTL rendering issue by using First Strong Isolate
+    option.title = '\u2068' + option.text + '\u2069';
+
     return $(`<span><i class="validationstatus ${classes}"></i> ${_.escape(option.text)}</span>`);
 };
 
@@ -1007,6 +1017,9 @@ var templateItilPriority = function(option) {
     if (priority_color.length > 0) {
         color_badge += `<i class='ti ti-circle-filled' style='color: ${_.escape(priority_color)}'></i>`;
     }
+
+    // Fix tooltip RTL rendering issue by using First Strong Isolate
+    option.title = '\u2068' + option.text + '\u2069';
 
     return $(`<span>${color_badge}&nbsp;${_.escape(option.text)}</span>`);
 };


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
This PR fixes an issue where the tooltip for Select2 components (such as the "Amortization Duration" field in the Management tab) displays text inverted for LTR languages (e.g., displaying "years 5" instead of "5 years"). 

Closes https://github.com/glpi-project/glpi/issues/25443

### Root Cause
In a previous UI update (https://github.com/glpi-project/glpi/commit/6c16db004e51f2a41a18f934e93ca47f58583b8a), `direction: rtl;` was added to the `.select2-selection__rendered` container in CSS to force long texts to truncate with an ellipsis on the left side instead of the right. While this works visually, the HTML `title` attribute inherits the container's computed CSS direction. Consequently, browsers render tooltips as Right-to-Left, which breaks the formatting of LTR strings that begin with numbers.

### Solution
Removing `direction: rtl;` from the CSS would break the left-ellipsis feature. Instead, this PR updates the Select2 templating functions in `js/common.js` to wrap the `title` attribute in Unicode Bidirectional control characters: **First Strong Isolate** (`\u2068`) and **Pop Directional Isolate** (`\u2069`).

### Why this is safe for all users (LTR and RTL)
The First Strong Isolate (FSI) dynamically determines text directionality based on the first strongly directional character in the string, isolating it completely from the parent container's forced RTL CSS.

- **For LTR Users (English, French, etc.):** In the string `"5 years"`, numbers and spaces are treated as "weak" and skipped. The letter `"y"` is the first strong character (LTR), so the browser formats the tooltip Left-to-Right natively.
- **For RTL Users (Arabic, Hebrew, etc.):** In the string `"5 سنوات"`, the Arabic letter `"س"` is the first strong character (RTL), so the browser natively formats the tooltip Right-to-Left.

This ensures tooltips display correctly across all languages without compromising the left-ellipsis UI feature.

## How to test
1. Go to **Assets > Computers** and open any computer.
2. Navigate to the **Management** tab.
3. Select "5 years" in the **Amortization duration** dropdown.
4. Hover your mouse over the field.
5. Verify the tooltip correctly displays as `"5 years"` (instead of `"years 5"`).

## Acknowledgments
A big thanks to [@cconard96](https://github.com/cconard96) for discovering the root cause of the issue reported at https://github.com/glpi-project/glpi/issues/25443!

## Screenshots (if appropriate):

<img width="1907" height="446" alt="image" src="https://github.com/user-attachments/assets/e99b17ff-2ff4-41a9-bdee-e6c7b4663128" />
