### PR TITLE
Fix location assignment for unmanaged inventory assets

### DIFF
--- a/src/Glpi/Inventory/MainAsset/Unmanaged.php
+++ b/src/Glpi/Inventory/MainAsset/Unmanaged.php
@@ -156,6 +156,8 @@ class Unmanaged extends MainAsset
 
         // append data from RuleImportEntity
         foreach ($this->ruleentity_data as $attribute => $value) {
+            $known_key = md5($attribute . $value);
+            $this->known_links[$known_key] = $value;
             $val->{$attribute} = $value;
         }
         // append data from RuleLocation

--- a/tests/functional/Glpi/Inventory/Assets/UnmanagedTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/UnmanagedTest.php
@@ -162,6 +162,13 @@ class UnmanagedTest extends AbstractInventoryAsset
         ]);
         $this->assertGreaterThan(0, $entities_id_b);
 
+        $location = new \Location();
+        $locations_id = $location->add([
+            'name'        => 'Location B',
+            'entities_id' => $entities_id_b,
+        ]);
+        $this->assertGreaterThan(0, $locations_id);
+
         // Add a rule for get entity tag (1)
         $rule = new \Rule();
         $input = [
@@ -199,6 +206,14 @@ class UnmanagedTest extends AbstractInventoryAsset
             'action_type' => 'regex_result',
             'field'       => '_affect_entity_by_tag',
             'value'       => '#0',
+        ];
+        $this->assertGreaterThan(0, $ruleaction->add($input));
+
+        $input = [
+            'rules_id'    => $rule1_id,
+            'action_type' => 'assign',
+            'field'       => 'locations_id',
+            'value'       => $locations_id,
         ];
         $this->assertGreaterThan(0, $ruleaction->add($input));
 
@@ -242,6 +257,15 @@ class UnmanagedTest extends AbstractInventoryAsset
 
         //check entity
         $this->assertEquals($entities_id_b, $unmanaged->fields['entities_id']);
+
+        // Check that the location assigned by RuleImportEntity is reused.
+        $this->assertEquals($locations_id, $unmanaged->fields['locations_id']);
+
+        // A new location named after the numerical ID must not be created.
+        $this->assertFalse($location->getFromDbByCrit([
+            'name'        => (string) $locations_id,
+            'entities_id' => $entities_id_b,
+        ]));
 
         //check for one NetworkPort
         $np = new \NetworkPort();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective.

## Description

- Fixes #25446.

During a NETDISCOVERY import, values returned by `RuleImportEntity` are copied
to the `Unmanaged` asset data but are not registered in `known_links`.

When the rule assigns an existing `locations_id`, `handleLinks()` may therefore
interpret the numerical ID as an external dropdown value and create a new
Location named after this ID instead of reusing the existing Location.

This change registers values returned by `RuleImportEntity` in `known_links`,
as is already done for values returned by `RuleLocation`.

## Reproduction case

1. Create an entity and an existing location in that entity.
2. Create an active `RuleImportEntity` rule matching an `Unmanaged`
   NETDISCOVERY inventory.
3. Configure the rule to assign the entity and the existing location.
4. Import a matching NETDISCOVERY inventory.
5. Without this fix, a new Location named after the numerical location ID may
   be created and assigned to the unmanaged asset.

The regression test uses only anonymized data already based on the existing
NETDISCOVERY functional test:

- inventory IP: `192.168.1.20`;
- entity: `Entity B`;
- location: `Location B`;
- asset type: `Unmanaged`.

## Tests

The existing test in
`tests/functional/Glpi/Inventory/Assets/UnmanagedTest.php` was extended to
verify that:

- the existing location selected by `RuleImportEntity` is assigned to the
  unmanaged asset;
- no new Location named after the numerical location ID is created.

PHP syntax checks and `git diff --check` completed successfully.

The fix was also functionally validated on GLPI 11.0.8 with a complete network
discovery. Newly created unmanaged assets were assigned to their expected
existing locations, and no locations named after numerical IDs were created.

The complete automated test suite was not run locally and is expected to be
validated by the project CI.

## AI usage disclosure

AI assistance was used to analyze the root cause and help prepare the code
change and anonymized regression test. The change was manually reviewed and
functionally validated on GLPI 11.0.8.