### PR TITLE
[HLAPI] Field level permissions

### DIFF
--- a/src/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/src/Glpi/Api/HL/Controller/AdministrationController.php
@@ -255,9 +255,7 @@ EOD,
                         'readOnly' => true,
                         'x-version-introduced' => '2.2.0',
                         'x-rights-conditions' => [
-                            'read' => static function () {
-                                return Session::haveRight(User::$rightname, User::READAUTHENT);
-                            },
+                            'read' => static fn() => Session::haveRight(User::$rightname, User::READAUTHENT),
                         ],
                     ],
                     'title' => self::getDropdownTypeSchema(class: UserTitle::class, full_schema: 'UserTitle') + ['x-version-introduced' => '2.2.0'],
@@ -428,9 +426,7 @@ EOD,
                         'type' => Doc\Schema::TYPE_BOOLEAN,
                         'description' => 'Is two-factor authentication enforced for members of this group',
                         'x-rights-conditions' => [
-                            'read' => static function () {
-                                return Session::haveRight(User::$rightname, User::READAUTHENT);
-                            },
+                            'read' => static fn() => Session::haveRight(User::$rightname, User::READAUTHENT),
                         ],
                     ],
                     'date_creation' => [

--- a/src/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/src/Glpi/Api/HL/Controller/AdministrationController.php
@@ -257,7 +257,7 @@ EOD,
                         'x-rights-conditions' => [
                             'read' => static function () {
                                 return Session::haveRight(User::$rightname, User::READAUTHENT);
-                            }
+                            },
                         ],
                     ],
                     'title' => self::getDropdownTypeSchema(class: UserTitle::class, full_schema: 'UserTitle') + ['x-version-introduced' => '2.2.0'],
@@ -430,7 +430,7 @@ EOD,
                         'x-rights-conditions' => [
                             'read' => static function () {
                                 return Session::haveRight(User::$rightname, User::READAUTHENT);
-                            }
+                            },
                         ],
                     ],
                     'date_creation' => [

--- a/src/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/src/Glpi/Api/HL/Controller/AdministrationController.php
@@ -50,6 +50,7 @@ use Glpi\Http\Request;
 use Glpi\Http\Response;
 use Glpi\UI\ThemeManager;
 use Group;
+use Notification;
 use Planning;
 use Profile;
 use Session;
@@ -253,6 +254,11 @@ EOD,
                         'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
                         'readOnly' => true,
                         'x-version-introduced' => '2.2.0',
+                        'x-rights-conditions' => [
+                            'read' => static function () {
+                                return Session::haveRight(User::$rightname, User::READAUTHENT);
+                            }
+                        ],
                     ],
                     'title' => self::getDropdownTypeSchema(class: UserTitle::class, full_schema: 'UserTitle') + ['x-version-introduced' => '2.2.0'],
                     'category' => self::getDropdownTypeSchema(class: UserCategory::class, full_schema: 'UserCategory') + ['x-version-introduced' => '2.2.0'],
@@ -421,6 +427,11 @@ EOD,
                         'x-field' => '2fa_enforced',
                         'type' => Doc\Schema::TYPE_BOOLEAN,
                         'description' => 'Is two-factor authentication enforced for members of this group',
+                        'x-rights-conditions' => [
+                            'read' => static function () {
+                                return Session::haveRight(User::$rightname, User::READAUTHENT);
+                            }
+                        ],
                     ],
                     'date_creation' => [
                         'type' => Doc\Schema::TYPE_STRING,
@@ -558,49 +569,76 @@ EOD,
                         'type' => Doc\Schema::TYPE_STRING,
                         'format' => Doc\Schema::FORMAT_STRING_EMAIL,
                         'maxLength' => 255,
+                        'x-rights-conditions' => [
+                            'read' => static fn() => Notification::canView(),
+                        ],
                     ],
                     'admin_email_name' => [
                         'x-version-introduced' => '2.3.0',
                         'type' => Doc\Schema::TYPE_STRING,
                         'maxLength' => 255,
+                        'x-rights-conditions' => [
+                            'read' => static fn() => Notification::canView(),
+                        ],
                     ],
                     'from_email' => [
                         'x-version-introduced' => '2.3.0',
                         'type' => Doc\Schema::TYPE_STRING,
                         'format' => Doc\Schema::FORMAT_STRING_EMAIL,
                         'maxLength' => 255,
+                        'x-rights-conditions' => [
+                            'read' => static fn() => Notification::canView(),
+                        ],
                     ],
                     'from_email_name' => [
                         'x-version-introduced' => '2.3.0',
                         'type' => Doc\Schema::TYPE_STRING,
                         'maxLength' => 255,
+                        'x-rights-conditions' => [
+                            'read' => static fn() => Notification::canView(),
+                        ],
                     ],
                     'noreply_email' => [
                         'x-version-introduced' => '2.3.0',
                         'type' => Doc\Schema::TYPE_STRING,
                         'format' => Doc\Schema::FORMAT_STRING_EMAIL,
                         'maxLength' => 255,
+                        'x-rights-conditions' => [
+                            'read' => static fn() => Notification::canView(),
+                        ],
                     ],
                     'noreply_email_name' => [
                         'x-version-introduced' => '2.3.0',
                         'type' => Doc\Schema::TYPE_STRING,
                         'maxLength' => 255,
+                        'x-rights-conditions' => [
+                            'read' => static fn() => Notification::canView(),
+                        ],
                     ],
                     'replyto_email' => [
                         'x-version-introduced' => '2.3.0',
                         'type' => Doc\Schema::TYPE_STRING,
                         'format' => Doc\Schema::FORMAT_STRING_EMAIL,
                         'maxLength' => 255,
+                        'x-rights-conditions' => [
+                            'read' => static fn() => Notification::canView(),
+                        ],
                     ],
                     'replyto_email_name' => [
                         'x-version-introduced' => '2.3.0',
                         'type' => Doc\Schema::TYPE_STRING,
                         'maxLength' => 255,
+                        'x-rights-conditions' => [
+                            'read' => static fn() => Notification::canView(),
+                        ],
                     ],
                     'notification_subject_tag' => [
                         'x-version-introduced' => '2.3.0',
                         'type' => Doc\Schema::TYPE_STRING,
                         'maxLength' => 255,
+                        'x-rights-conditions' => [
+                            'read' => static fn() => Notification::canView(),
+                        ],
                     ],
                     'ldap_dn' => [
                         'x-version-introduced' => '2.3.0',
@@ -627,6 +665,9 @@ EOD,
                     'mailing_signature' => [
                         'x-version-introduced' => '2.3.0',
                         'type' => Doc\Schema::TYPE_STRING,
+                        'x-rights-conditions' => [
+                            'read' => static fn() => Notification::canView(),
+                        ],
                     ],
                     'url_base' => [
                         'x-version-introduced' => '2.3.0',

--- a/src/Glpi/Api/HL/Controller/AssetController.php
+++ b/src/Glpi/Api/HL/Controller/AssetController.php
@@ -685,7 +685,7 @@ final class AssetController extends AbstractController
                     'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
                     'minimum' => 0,
                     'x-rights-conditions' => [
-                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                        'read' => static fn() => Session::haveRight(Infocom::$rightname, READ),
                     ],
                 ],
                 'last_inventory_update' => [
@@ -811,7 +811,7 @@ final class AssetController extends AbstractController
                     'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
                     'minimum' => 0,
                     'x-rights-conditions' => [
-                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                        'read' => static fn() => Session::haveRight(Infocom::$rightname, READ),
                     ],
                 ],
                 'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
@@ -871,7 +871,7 @@ final class AssetController extends AbstractController
                     'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
                     'minimum' => 0,
                     'x-rights-conditions' => [
-                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                        'read' => static fn() => Session::haveRight(Infocom::$rightname, READ),
                     ],
                 ],
                 'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
@@ -940,7 +940,7 @@ final class AssetController extends AbstractController
                     'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
                     'minimum' => 0,
                     'x-rights-conditions' => [
-                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                        'read' => static fn() => Session::haveRight(Infocom::$rightname, READ),
                     ],
                 ],
                 'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
@@ -999,7 +999,7 @@ final class AssetController extends AbstractController
                     'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
                     'x-version-introduced' => '2.3.0',
                     'x-rights-conditions' => [
-                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                        'read' => static fn() => Session::haveRight(Infocom::$rightname, READ),
                     ],
                 ],
                 'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
@@ -1090,7 +1090,7 @@ final class AssetController extends AbstractController
                     'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
                     'minimum' => 0,
                     'x-rights-conditions' => [
-                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                        'read' => static fn() => Session::haveRight(Infocom::$rightname, READ),
                     ],
                 ],
                 'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
@@ -1614,7 +1614,7 @@ final class AssetController extends AbstractController
                     'minimum' => 0,
                     'x-version-introduced' => '2.3.0',
                     'x-rights-conditions' => [
-                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                        'read' => static fn() => Session::haveRight(Infocom::$rightname, READ),
                     ],
                 ],
             ],

--- a/src/Glpi/Api/HL/Controller/AssetController.php
+++ b/src/Glpi/Api/HL/Controller/AssetController.php
@@ -130,6 +130,7 @@ use Rack;
 use RackModel;
 use RackType;
 use RuntimeException;
+use Session;
 use SNMPCredential;
 use Software;
 use SoftwareCategory;
@@ -683,6 +684,9 @@ final class AssetController extends AbstractController
                     'type' => Doc\Schema::TYPE_NUMBER,
                     'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
                     'minimum' => 0,
+                    'x-rights-conditions' => [
+                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                    ],
                 ],
                 'last_inventory_update' => [
                     'x-version-introduced' => '2.3.0',
@@ -806,6 +810,9 @@ final class AssetController extends AbstractController
                     'type' => Doc\Schema::TYPE_NUMBER,
                     'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
                     'minimum' => 0,
+                    'x-rights-conditions' => [
+                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                    ],
                 ],
                 'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
             ],
@@ -863,6 +870,9 @@ final class AssetController extends AbstractController
                     'type' => Doc\Schema::TYPE_NUMBER,
                     'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
                     'minimum' => 0,
+                    'x-rights-conditions' => [
+                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                    ],
                 ],
                 'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
                 'sysdescr' => ['type' => Doc\Schema::TYPE_STRING, 'x-version-introduced' => '2.3.0'],
@@ -929,6 +939,9 @@ final class AssetController extends AbstractController
                     'type' => Doc\Schema::TYPE_NUMBER,
                     'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
                     'minimum' => 0,
+                    'x-rights-conditions' => [
+                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                    ],
                 ],
                 'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
             ],
@@ -981,7 +994,14 @@ final class AssetController extends AbstractController
                 'is_global' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
                 'is_template' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
                 'template_name' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'x-version-introduced' => '2.3.0'],
-                'ticket_tco' => ['type' => Doc\Schema::TYPE_NUMBER, 'format' => Doc\Schema::FORMAT_NUMBER_FLOAT, 'x-version-introduced' => '2.3.0'],
+                'ticket_tco' => [
+                    'type' => Doc\Schema::TYPE_NUMBER,
+                    'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
+                    'x-version-introduced' => '2.3.0',
+                    'x-rights-conditions' => [
+                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                    ],
+                ],
                 'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
                 'last_inventory_update' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME, 'x-version-introduced' => '2.3.0'],
             ],
@@ -1069,6 +1089,9 @@ final class AssetController extends AbstractController
                     'type' => Doc\Schema::TYPE_NUMBER,
                     'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
                     'minimum' => 0,
+                    'x-rights-conditions' => [
+                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                    ],
                 ],
                 'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
                 'sysdescr' => ['type' => Doc\Schema::TYPE_STRING, 'x-version-introduced' => '2.3.0'],
@@ -1590,6 +1613,9 @@ final class AssetController extends AbstractController
                     'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
                     'minimum' => 0,
                     'x-version-introduced' => '2.3.0',
+                    'x-rights-conditions' => [
+                        'read' => static fn () => Session::haveRight(Infocom::$rightname, READ)
+                    ],
                 ],
             ],
         ];

--- a/src/Glpi/Api/HL/Controller/GraphQLController.php
+++ b/src/Glpi/Api/HL/Controller/GraphQLController.php
@@ -42,6 +42,7 @@ use Glpi\Api\HL\RouteVersion;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
+use GraphQL\Error\Error;
 use GraphQL\Utils\SchemaPrinter;
 
 #[Route(path: '/GraphQL', priority: 1, tags: ['GraphQL'])]
@@ -72,6 +73,20 @@ final class GraphQLController extends AbstractController
             // More correct handling of paginations is adding a "pagination" field to the "extensions" part of the response, which is designed for this kind of metadata.
             $response_data['extensions']['pagination'] = $result['context']->pagination;
         }
+        if (isset($result['context']->field_errors)) {
+            /** @var Error $field_error */
+            foreach ($result['context']->field_errors as $field_error) {
+                $response_data['errors'][] = [
+                    'message' => $field_error->getMessage(),
+                    'path' => $field_error->getPath(),
+                    'locations' => $field_error->getLocations(),
+                    'extensions' => [
+                        'code' => 'field_access_denied',
+                    ],
+                ];
+            }
+        }
+
         return new JSONResponse($response_data, 200, $headers);
     }
 

--- a/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
+++ b/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
@@ -50,6 +50,7 @@ use Glpi\DBAL\QuerySubQuery;
 use Glpi\Debug\Profiler;
 use GraphQL\Deferred;
 use GraphQL\Error\Error;
+use GraphQL\Language\AST\FieldNode;
 use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ResolveInfo;
 use stdClass;
@@ -354,8 +355,8 @@ class DefaultResolvers
         $root_field_node = $info->fieldNodes[0];
         if (isset($root_field_node->selectionSet)) {
             foreach ($root_field_node->selectionSet->selections as $selection) {
-                if ($selection->name->value === $field_name) {
-                    $requested_field_name = $selection->alias?->value ?? $field_name;
+                if ($selection instanceof FieldNode && $selection->name->value === $field_name) {
+                    $requested_field_name = $selection->alias->value ?? $field_name;
                     break;
                 }
             }

--- a/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
+++ b/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
@@ -122,11 +122,11 @@ class DefaultResolvers
     /**
      * @param mixed $source
      * @param array<string, mixed> $args
-     * @param object $context
+     * @param stdClass $context
      * @param ResolveInfo $info
      * @return array<string, mixed>|Deferred|null
      */
-    public function resolveObjectField(mixed $source, array $args, object $context, ResolveInfo $info): array|Deferred|null
+    public function resolveObjectField(mixed $source, array $args, stdClass $context, ResolveInfo $info): array|Deferred|null
     {
         $fields_requested = array_keys($info->getFieldSelection(1));
         $field_name = $info->fieldName;
@@ -308,11 +308,11 @@ class DefaultResolvers
     /**
      * @param mixed $source
      * @param array<string, mixed> $args
-     * @param object $context
+     * @param stdClass $context
      * @param ResolveInfo $info
      * @return mixed
      */
-    public function resolveScalarField(mixed $source, array $args, object $context, ResolveInfo $info): mixed
+    public function resolveScalarField(mixed $source, array $args, stdClass $context, ResolveInfo $info): mixed
     {
         $field_name = $info->fieldName;
         $parent_schema = $this->getSchemaForObjectName($info->parentType->name);
@@ -345,10 +345,10 @@ class DefaultResolvers
      * As the field selection in the GraphQL resolve info is not changed, only the fetching of data will be blocked.
      * The fields will still be present in the GraphQL response, but will be null if the user does not have permission to view them.
      * Instead, an error will be added to the context for each field that the user does not have permission to view to inform the user of the issue.
-     * @param array $schema
-     * @param array $requested_fields
+     * @param array<string, mixed> $schema
+     * @param string[] $requested_fields
      * @param stdClass $context
-     * @return array
+     * @return string[]
      */
     private function getValidFieldSelection(array $schema, array $requested_fields, ResolveInfo $info, stdClass $context): array
     {

--- a/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
+++ b/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
@@ -38,6 +38,8 @@ use CommonDBTM;
 use DBConnection;
 use Glpi\Api\HL\APIException;
 use Glpi\Api\HL\Doc\Schema;
+use Glpi\Api\HL\GraphQL\Error\FieldAccessDeniedError;
+use Glpi\Api\HL\ResourceAccessor;
 use Glpi\Api\HL\RightConditionNotMetException;
 use Glpi\Api\HL\RSQL\RSQLException;
 use Glpi\Api\HL\Schemas;
@@ -168,6 +170,9 @@ class DefaultResolvers
         if ($schema === null) {
             throw new Error('Unable to resolve field "' . $field_name . '": schema not found');
         }
+
+        $fields_requested = $this->getValidFieldSelection($schema, $fields_requested, $info, $context);
+
         $needed = $this->object_cache->getNeeded($schema_name, [$id], $fields_requested);
         if ($needed === []) {
             // Object is already cached with all requested fields
@@ -176,23 +181,23 @@ class DefaultResolvers
         $fields_requested = $needed[$id];
 
         $this->object_cache->add($schema_name, $id, $fields_requested);
-        return new Deferred(function () use ($schema_name, $schema, $id, &$args) {
-            Profiler::getInstance()->start('GraphQL2::resolveObjectField::deferred::' . $schema_name, Profiler::CATEGORY_HLAPI);
+        return new Deferred(function () use ($schema_name, $schema, $id, &$args, $info) {
+            Profiler::getInstance()->start('GraphQL::resolveObjectField::deferred::' . $schema_name, Profiler::CATEGORY_HLAPI);
             $to_load = $this->object_cache->getPending($schema_name);
             if ($to_load === []) {
                 $r = $this->object_cache->get($schema_name, $id)?->data;
-                Profiler::getInstance()->stop('GraphQL2::resolveObjectField::deferred::' . $schema_name);
+                Profiler::getInstance()->stop('GraphQL::resolveObjectField::deferred::' . $schema_name);
                 return $r;
             }
 
             $args['id'] = $to_load['id'];
-            $it = $this->db->request($this->getCriteriaForObject($schema, $to_load['fields'], $args));
+            $it = $this->db->request($this->getCriteriaForObject($schema, $to_load['fields'], $args, $info));
             foreach ($it as $data) {
                 $this->object_cache->set($schema_name, $data['id'], $data);
             }
 
             $r = $this->object_cache->get($schema_name, $id)?->data;
-            Profiler::getInstance()->stop('GraphQL2::resolveObjectField::deferred::' . $schema_name);
+            Profiler::getInstance()->stop('GraphQL::resolveObjectField::deferred::' . $schema_name);
             return $r;
         });
     }
@@ -224,12 +229,14 @@ class DefaultResolvers
             return $source[$field_name];
         }
 
+        $fields_requested = $this->getValidFieldSelection($schema, $fields_requested, $info, $context);
+
         foreach ($ids as $id) {
             $this->object_cache->add($schema_name, (int) $id, $fields_requested);
         }
 
         $executor = function () use (&$context, $source, $schema_name, $schema, $ids, &$args, $info) {
-            Profiler::getInstance()->start('GraphQL2::resolveListField::executor::' . $schema_name, Profiler::CATEGORY_HLAPI);
+            Profiler::getInstance()->start('GraphQL::resolveListField::executor::' . $schema_name, Profiler::CATEGORY_HLAPI);
             $to_load = $this->object_cache->getPending($schema_name);
             if ($to_load === []) {
                 $results = [];
@@ -239,7 +246,7 @@ class DefaultResolvers
                         $results[] = $cached_object->data;
                     }
                 }
-                Profiler::getInstance()->stop('GraphQL2::resolveListField::executor::' . $schema_name);
+                Profiler::getInstance()->stop('GraphQL::resolveListField::executor::' . $schema_name);
                 return $results;
             }
             if ($source !== null) {
@@ -247,7 +254,7 @@ class DefaultResolvers
             } else {
                 $ids = [];
             }
-            $criteria = $this->getCriteriaForObject($schema, $to_load['fields'], $args);
+            $criteria = $this->getCriteriaForObject($schema, $to_load['fields'], $args, $info);
             $it = $this->db->request($criteria);
             foreach ($it as $data) {
                 // decode all array fields so that parsing can continue as expected
@@ -288,7 +295,7 @@ class DefaultResolvers
                     $results[] = $cached_object->data;
                 }
             }
-            Profiler::getInstance()->stop('GraphQL2::resolveListField::executor::' . $schema_name);
+            Profiler::getInstance()->stop('GraphQL::resolveListField::executor::' . $schema_name);
             return $results;
         };
 
@@ -334,18 +341,52 @@ class DefaultResolvers
     }
 
     /**
+     * Checks the requested fields against the schema, applying any field-level read permission checks and removing any fields that the user does not have permission to view.
+     * As the field selection in the GraphQL resolve info is not changed, only the fetching of data will be blocked.
+     * The fields will still be present in the GraphQL response, but will be null if the user does not have permission to view them.
+     * Instead, an error will be added to the context for each field that the user does not have permission to view to inform the user of the issue.
+     * @param array $schema
+     * @param array $requested_fields
+     * @param stdClass $context
+     * @return array
+     */
+    private function getValidFieldSelection(array $schema, array $requested_fields, ResolveInfo $info, stdClass $context): array
+    {
+        $valid_fields = [];
+        foreach ($requested_fields as $field) {
+            if (!array_key_exists($field, $schema['properties'])) {
+                continue;
+            }
+            if (isset($schema['properties'][$field]['x-rights-conditions']['read'])) {
+                $check_result = $schema['properties'][$field]['x-rights-conditions']['read']();
+                if (is_array($check_result)) {
+                    throw new \LogicException('SQL condition field right checks are not currently supported.');
+                }
+                if ((bool) $check_result === false) {
+                    $context->field_errors ??= [];
+                    $context->field_errors[] = new FieldAccessDeniedError(nodes: $info->fieldNodes, path: [...$info->path, $field]);
+                    continue;
+                }
+            }
+            $valid_fields[] = $field;
+        }
+        return $valid_fields;
+    }
+
+    /**
      * @param array<string, mixed> $schema
      * @param string[] $field_selection
      * @param array<string, mixed> $request_params
+     * @param ResolveInfo $info
      * @return array<string, mixed>
      * @throws Error
      * @throws APIException
      * @throws RSQLException
      * @throws RightConditionNotMetException
      */
-    private function getCriteriaForObject(array $schema, array $field_selection, array $request_params): array
+    private function getCriteriaForObject(array $schema, array $field_selection, array $request_params, ResolveInfo $info): array
     {
-        Profiler::getInstance()->start('GraphQL2::getCriteriaForObject', Profiler::CATEGORY_HLAPI);
+        Profiler::getInstance()->start('GraphQL::getCriteriaForObject', Profiler::CATEGORY_HLAPI);
         if (!array_key_exists('x-table', $schema) && !array_key_exists('x-itemtype', $schema)) {
             throw new Error("Schema does not define a table or itemtype to query.");
         }
@@ -356,6 +397,7 @@ class DefaultResolvers
             'WHERE' => [],
         ];
 
+        $schema = ResourceAccessor::applyFieldReadRestrictions($schema, true);
         $search = new Search($schema, $request_params);
 
         if (!in_array('id', $field_selection, true)) {
@@ -423,10 +465,14 @@ class DefaultResolvers
         $criteria['GROUPBY'] = ['_.id'];
 
         $search->addVisibilityCriteria($criteria);
-        $search->addReadRestrictCriteria($criteria);
+        try {
+            $search->addReadRestrictCriteria($criteria);
+        } catch (RightConditionNotMetException $e) {
+            throw new Error('Unable to resolve field "' . $info->fieldName . '": schema not found or not viewable');
+        }
         $search->addPaginationCriteria($criteria);
         $search->addSortingCriteria($criteria);
-        Profiler::getInstance()->stop('GraphQL2::getCriteriaForObject');
+        Profiler::getInstance()->stop('GraphQL::getCriteriaForObject');
 
         return $criteria;
     }

--- a/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
+++ b/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
@@ -341,6 +341,30 @@ class DefaultResolvers
     }
 
     /**
+     * Returns the requested field name for a given field and path.
+     * This may be the real field name, or an alias.
+     * @param string $field_name The real field name.
+     * @param ResolveInfo $info
+     * @return string
+     */
+    private function getRequestedFieldName(string $field_name, ResolveInfo $info): string
+    {
+        $requested_field_name = $field_name;
+
+        $root_field_node = $info->fieldNodes[0];
+        if (isset($root_field_node->selectionSet)) {
+            foreach ($root_field_node->selectionSet->selections as $selection) {
+                if ($selection->name->value === $field_name) {
+                    $requested_field_name = $selection->alias?->value ?? $field_name;
+                    break;
+                }
+            }
+        }
+
+        return $requested_field_name;
+    }
+
+    /**
      * Checks the requested fields against the schema, applying any field-level read permission checks and removing any fields that the user does not have permission to view.
      * As the field selection in the GraphQL resolve info is not changed, only the fetching of data will be blocked.
      * The fields will still be present in the GraphQL response, but will be null if the user does not have permission to view them.
@@ -353,6 +377,7 @@ class DefaultResolvers
     private function getValidFieldSelection(array $schema, array $requested_fields, ResolveInfo $info, stdClass $context): array
     {
         $valid_fields = [];
+
         foreach ($requested_fields as $field) {
             if (!array_key_exists($field, $schema['properties'])) {
                 continue;
@@ -364,7 +389,8 @@ class DefaultResolvers
                 }
                 if ((bool) $check_result === false) {
                     $context->field_errors ??= [];
-                    $context->field_errors[] = new FieldAccessDeniedError(nodes: $info->fieldNodes, path: [...$info->path, $field]);
+                    $requested_field_name = $this->getRequestedFieldName($field, $info);
+                    $context->field_errors[] = new FieldAccessDeniedError(nodes: $info->fieldNodes, path: [...$info->path, $requested_field_name]);
                     continue;
                 }
             }

--- a/src/Glpi/Api/HL/GraphQL/Error/FieldAccessDeniedError.php
+++ b/src/Glpi/Api/HL/GraphQL/Error/FieldAccessDeniedError.php
@@ -34,7 +34,6 @@
 
 namespace Glpi\Api\HL\GraphQL\Error;
 
-use GraphQL\Error\ClientAware;
 use GraphQL\Error\Error;
 use GraphQL\Language\Source;
 

--- a/src/Glpi/Api/HL/GraphQL/Error/FieldAccessDeniedError.php
+++ b/src/Glpi/Api/HL/GraphQL/Error/FieldAccessDeniedError.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL\GraphQL\Error;
+
+use GraphQL\Error\ClientAware;
+use GraphQL\Error\Error;
+use GraphQL\Language\Source;
+
+class FieldAccessDeniedError extends Error
+{
+    public function __construct($nodes = null, ?Source $source = null, ?array $positions = null, ?array $path = null, ?\Throwable $previous = null, ?array $extensions = null, ?array $unaliasedPath = null)
+    {
+        $field_path = implode('.', $path ?? []);
+        $message = "You do not have permission to view the field $field_path";
+        parent::__construct($message, $nodes, $source, $positions, $path, $previous, $extensions, $unaliasedPath);
+    }
+
+    public function isClientSafe(): bool
+    {
+        return true;
+    }
+}

--- a/src/Glpi/Api/HL/ResourceAccessor.php
+++ b/src/Glpi/Api/HL/ResourceAccessor.php
@@ -269,6 +269,34 @@ final class ResourceAccessor
             }
         }
 
+        $fn_filter_properties = static function (array $props, string $parent_path = '', array &$removed_paths = []) use (&$fn_filter_properties) {
+            foreach ($props as $key => $prop) {
+                if (isset($prop['x-rights-conditions']['read'])) {
+                    $check_result = $prop['x-rights-conditions']['read']();
+                    if (is_array($check_result)) {
+                        throw new \LogicException('SQL condition field right checks are not currently supported.');
+                    }
+                    if ((bool) $check_result === false) {
+                        $removed_paths[] = $parent_path === '' ? $key : $parent_path . '.' . $key;
+                        unset($props[$key]);
+                        continue;
+                    }
+                }
+                if (isset($prop['properties'])) {
+                    $props[$key]['properties'] = $fn_filter_properties($prop['properties'], $parent_path === '' ? $key : $parent_path . '.' . $key, $removed_paths);
+                } elseif (isset($prop['items']['properties'])) {
+                    $props[$key]['items']['properties'] = $fn_filter_properties($prop['items']['properties'], $parent_path === '' ? $key : $parent_path . '.' . $key, $removed_paths);
+                }
+            }
+            return $props;
+        };
+        $removed_paths = [];
+        if (isset($filtered_schema['properties'])) {
+            $filtered_schema['properties'] = $fn_filter_properties($filtered_schema['properties'], '', $removed_paths);
+        } elseif (isset($filtered_schema['items']['properties'])) {
+            $filtered_schema['items']['properties'] = $fn_filter_properties($filtered_schema['items']['properties'], '', $removed_paths);
+        }
+
         return $filtered_schema;
     }
 

--- a/tests/functional/Glpi/Api/HL/Controller/AdministrationControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AdministrationControllerTest.php
@@ -39,6 +39,7 @@ use Glpi\Event;
 use Glpi\Http\Request;
 use Glpi\Tests\HLAPITestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ValidatorSubstitute;
 
 class AdministrationControllerTest extends HLAPITestCase
 {
@@ -755,5 +756,109 @@ class AdministrationControllerTest extends HLAPITestCase
             create_params: $create_params,
             extra_options: ['skip_update_test' => $itemtype === 'ApprovalSubstitute']
         );
+    }
+
+    public function testCannotViewLastSyncWithoutPermission(): void
+    {
+        // Technician profile can read users but doesn't have Read auth permission
+        $this->login('tech', 'tech');
+
+        $this->graphql->call('query { User { id username date_sync } }', function ($call) {
+            $call->response
+                ->isPartialError()
+                ->hasFieldAccessDenied('User.date_sync');
+        });
+        $this->api->call(new Request('GET', '/Administration/User/' . getItemByTypeName('User', 'tech', true)), function ($call) {
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) {
+                    $this->assertArrayHasKey('id', $content);
+                    $this->assertArrayHasKey('username', $content);
+                    $this->assertArrayNotHasKey('date_sync', $content);
+                });
+        });
+    }
+
+    public function testCannotViewGroupMFAWithoutPermission(): void
+    {
+        // Technician profile can read groups but doesn't have Read auth permission
+        $this->login('tech', 'tech');
+
+        $this->graphql->call('query { Group { mfa_enforced } }', function ($call) {
+            $call->response
+                ->isPartialError()
+                ->hasFieldAccessDenied('Group.mfa_enforced');
+        });
+
+        $this->api->call(new Request('GET', '/Administration/Group/' . getItemByTypeName('Group', '_test_group_1', true)), function ($call) {
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) {
+                    $this->assertArrayHasKey('id', $content);
+                    $this->assertArrayHasKey('name', $content);
+                    $this->assertArrayNotHasKey('mfa_enforced', $content);
+                });
+        });
+    }
+
+    public function testCannotViewEntityNotificationFieldsWithoutPermission(): void
+    {
+        $to_check = [
+            'admin_email', 'admin_email_name', 'from_email', 'from_email_name', 'noreply_email', 'noreply_email_name',
+            'replyto_email', 'replyto_email_name', 'notification_subject_tag', 'mailing_signature',
+        ];
+        // Tech has permission to read entities but is missing the READ permission for notifications, so they shouldn't see notification fields on entities
+        $this->login('tech', 'tech');
+
+        $this->graphql->call('query { Entity { id name ' . implode(' ', $to_check) . ' } }', function ($call) use ($to_check) {
+            $call->response
+                ->isPartialError();
+            foreach ($to_check as $field) {
+                $call->response->hasFieldAccessDenied('Entity.' . $field);
+            }
+        });
+
+        $this->api->call(new Request('GET', '/Administration/Entity/' . getItemByTypeName('Entity', '_test_root_entity', true)), function ($call) use ($to_check) {
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) use ($to_check) {
+                    $this->assertArrayHasKey('id', $content);
+                    $this->assertArrayHasKey('name', $content);
+                    foreach ($to_check as $field) {
+                        $this->assertArrayNotHasKey($field, $content);
+                    }
+                });
+        });
+    }
+
+    public function testCanSeeOnlyOwnApprovalSubstitute(): void
+    {
+        $postonly_users_id = getItemByTypeName('User', 'post-only', true);
+        $tech_users_id = getItemByTypeName('User', 'tech', true);
+        $this->createItem(ValidatorSubstitute::class, [
+            'users_id' => $postonly_users_id,
+            'users_id_substitute' => $tech_users_id,
+        ]);
+        $this->createItem(ValidatorSubstitute::class, [
+            'users_id' => $tech_users_id,
+            'users_id_substitute' => $postonly_users_id,
+        ]);
+        $this->login('post-only', 'postonly');
+        $this->graphql->call('query { ApprovalSubstitute { id substitute { id } } }', function ($call) use ($tech_users_id) {
+            $call->response
+                ->data('ApprovalSubstitute', function ($data) use ($tech_users_id) {
+                    $this->assertCount(1, $data);
+                    $this->assertEquals($tech_users_id, $data[0]['substitute']['id']);
+                });
+        });
+
+        $this->login('tech', 'tech');
+        $this->graphql->call('query { ApprovalSubstitute { substitute { id } } }', function ($call) use ($postonly_users_id) {
+            $call->response
+                ->data('ApprovalSubstitute', function ($data) use ($postonly_users_id) {
+                    $this->assertCount(1, $data);
+                    $this->assertEquals($postonly_users_id, $data[0]['substitute']['id']);
+                });
+        });
     }
 }

--- a/tests/functional/Glpi/Api/HL/Controller/AssetControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AssetControllerTest.php
@@ -44,7 +44,10 @@ use Glpi\Http\Request;
 use Glpi\Tests\HLAPITestCase;
 use Group;
 use Group_Item;
+use Infocom;
 use Item_RemoteManagement;
+use Monitor;
+use NetworkPort;
 use OperatingSystem;
 use OperatingSystemArchitecture;
 use OperatingSystemEdition;
@@ -954,6 +957,48 @@ class AssetControllerTest extends HLAPITestCase
                         $this->assertContains($id, $returned_ids);
                     }
                 });
+        });
+    }
+
+    public function testTicketTCOFieldRights(): void
+    {
+        $this->loginWeb('tech', 'tech');
+        $_SESSION['glpiactiveprofile'][Infocom::$rightname] |= READ;
+        $this->graphql->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
+        $this->graphql->call(<<<GRAPHQL
+            query {
+                Computer { id ticket_tco }
+                Monitor { id ticket_tco }
+                NetworkEquipment { id ticket_tco }
+                Peripheral { id ticket_tco }
+                Phone { id ticket_tco }
+                Printer { id ticket_tco }
+                Software { id ticket_tco }
+            }
+GRAPHQL, function ($call) {
+            $call->response->isOK();
+        });
+        $_SESSION['glpiactiveprofile'][Infocom::$rightname] &= ~READ;
+        $this->graphql->call(<<<GRAPHQL
+            query {
+                Computer { id ticket_tco }
+                Monitor { id ticket_tco }
+                NetworkEquipment { id ticket_tco }
+                Peripheral { id ticket_tco }
+                Phone { id ticket_tco }
+                Printer { id ticket_tco }
+                Software { id ticket_tco }
+            }
+GRAPHQL, function ($call) {
+            $call->response
+                ->isPartialError()
+                ->hasFieldAccessDenied('Computer.ticket_tco')
+                ->hasFieldAccessDenied('Monitor.ticket_tco')
+                ->hasFieldAccessDenied('NetworkEquipment.ticket_tco')
+                ->hasFieldAccessDenied('Peripheral.ticket_tco')
+                ->hasFieldAccessDenied('Phone.ticket_tco')
+                ->hasFieldAccessDenied('Printer.ticket_tco')
+                ->hasFieldAccessDenied('Software.ticket_tco');
         });
     }
 }

--- a/tests/functional/Glpi/Api/HL/Controller/AssetControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AssetControllerTest.php
@@ -46,8 +46,6 @@ use Group;
 use Group_Item;
 use Infocom;
 use Item_RemoteManagement;
-use Monitor;
-use NetworkPort;
 use OperatingSystem;
 use OperatingSystemArchitecture;
 use OperatingSystemEdition;

--- a/tests/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
@@ -177,7 +177,7 @@ class GraphQLControllerTest extends HLAPITestCase
             'is_visible_computer' => 1,
             'is_visible_monitor' => 0,
         ]));
-        $computer = new \Computer();
+        $computer = new Computer();
         $this->assertGreaterThan(0, $computers_id = $computer->add([
             'name' => __FUNCTION__,
             'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),

--- a/tests/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units\Glpi\Api\HL\Controller;
 
+use Computer;
 use Glpi\Api\HL\Middleware\InternalAuthMiddleware;
 use Glpi\Api\HL\Router;
 use Glpi\Http\Request;
@@ -496,6 +497,57 @@ class GraphQLControllerTest extends HLAPITestCase
                     $ticket = $tickets[0];
                     $this->assertEquals('New', $ticket['status']['name']);
                 });
+        });
+    }
+
+    public function testFieldAccessDenied(): void
+    {
+        global $DB;
+
+        $this->login('tech', 'tech');
+
+        // Ensure at least one computer has a user to trigger the resolver on the User field to have the date_sync field visibility evaluated
+        $DB->insert(Computer::getTable(), [
+            'name' => __FUNCTION__,
+            'entities_id' => $this->getTestRootEntity(true),
+            'users_id' => getItemByTypeName('User', 'glpi', true),
+        ]);
+        $DB->insert(Computer::getTable(), [
+            'name' => __FUNCTION__ . '2',
+            'entities_id' => $this->getTestRootEntity(true),
+            'users_id' => getItemByTypeName('User', 'glpi', true),
+        ]);
+
+        // Direct access to a field the user does not have access to
+        $this->graphql->call('query { User { id username date_sync } }', function ($call) {
+            $call->response
+                ->isPartialError()
+                ->hasFieldAccessDenied('User.date_sync');
+        });
+
+        $this->graphql->call('query { Computer { id name user { id username date_sync } } }', function ($call) {
+            $call->response
+                ->isPartialError()
+                ->hasFieldAccessDenied('Computer.user.date_sync');
+        });
+
+        $DB->insert('glpi_users', [
+            'name' => __FUNCTION__,
+            'date_sync' => '2026-07-01 06:07:00',
+        ]);
+
+        // Filtering by date_sync should not affect the results as missing fields are silently ignored currently
+        $this->graphql->call('query { User(filter: "date_sync=gt=2026-01-01") { id username } }', function ($call) {
+            $call->response
+                ->isOK()
+                ->data('User', function ($users) {
+                    $this->assertGreaterThan(4, count($users));
+                });
+        });
+
+        // Cannot sort by field not in the used schema
+        $this->graphql->call('query { User(sort: "date_sync") { id username } }', function ($call) {
+            $call->response->isCompletelyError();
         });
     }
 }

--- a/tests/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
@@ -531,6 +531,13 @@ class GraphQLControllerTest extends HLAPITestCase
                 ->hasFieldAccessDenied('Computer.user.date_sync');
         });
 
+        // Error message adapts to aliases
+        $this->graphql->call('query { Computer { id name owner:user { id username last_sync:date_sync } } }', function ($call) {
+            $call->response
+                ->isPartialError()
+                ->hasFieldAccessDenied('Computer.owner.last_sync');
+        });
+
         $DB->insert('glpi_users', [
             'name' => __FUNCTION__,
             'date_sync' => '2026-07-01 06:07:00',

--- a/tests/functional/Glpi/Api/HL/ResourceAccessorTest.php
+++ b/tests/functional/Glpi/Api/HL/ResourceAccessorTest.php
@@ -35,11 +35,13 @@
 namespace tests\units\Glpi\Api\HL;
 
 use Glpi\Api\HL\Controller\AbstractController;
+use Glpi\Api\HL\Controller\AdministrationController;
 use Glpi\Api\HL\ResourceAccessor;
-use Glpi\Tests\GLPITestCase;
+use Glpi\Api\HL\Router;
+use Glpi\Tests\DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-class ResourceAccessorTest extends GLPITestCase
+class ResourceAccessorTest extends DbTestCase
 {
     public static function getInputParamsBySchemaProvider()
     {
@@ -195,5 +197,91 @@ class ResourceAccessorTest extends GLPITestCase
                 'maximum' => 300,
             ],
         ], $response_data['detail']['weight']);
+    }
+
+    public function testApplyFieldReadRestrictions(): void
+    {
+        global $DB;
+
+        $this->login('post-only', 'postonly');
+        $user_schema = AdministrationController::getKnownSchemas(Router::API_VERSION)['User'];
+        $filtered = $this->callPrivateMethod(ResourceAccessor::class, 'applyFieldReadRestrictions', $user_schema);
+        $this->assertArrayHasKey('properties', $filtered);
+        $this->assertArrayHasKey('id', $filtered['properties']);
+        $this->assertArrayHasKey('username', $filtered['properties']);
+        $this->assertArrayHasKey('phone', $filtered['properties']);
+        $this->assertArrayHasKey('picture', $filtered['properties']);
+        $this->assertArrayNotHasKey('date_sync', $filtered['properties']);
+
+        $this->login('tech', 'tech');
+        $result = json_decode((string) ResourceAccessor::searchBySchema($user_schema, ['limit' => 1])->getBody(), true);
+        $this->assertArrayHasKey('id', $result[0]);
+        $this->assertArrayHasKey('username', $result[0]);
+        $this->assertArrayNotHasKey('date_sync', $result[0]);
+
+        $result = json_decode((string) ResourceAccessor::getOneBySchema($user_schema, ['id' => 2], [])->getBody(), true);
+        $this->assertArrayHasKey('id', $result);
+        $this->assertArrayHasKey('username', $result);
+        $this->assertArrayNotHasKey('date_sync', $result);
+
+        // clear readOnly flag on date_sync field to test updates
+        $user_schema['properties']['date_sync']['readOnly'] = false;
+
+        // test updating as Super-Admin just to ensure the test is set up correctly
+        $this->login();
+        ResourceAccessor::updateBySchema($user_schema, ['id' => 2], ['date_sync' => '2026-07-01 05:06:00']);
+        $this->assertEquals(
+            expected: '2026-07-01 05:06:00',
+            actual: $DB->request([
+                'SELECT' => ['date_sync'],
+                'FROM' => 'glpi_users',
+                'WHERE' => ['id' => 2],
+            ])->current()['date_sync']
+        );
+
+        $this->login('tech', 'tech');
+        $response = ResourceAccessor::updateBySchema($user_schema, ['id' => 2], ['date_sync' => '2026-07-02 06:07:00']);
+        // Request is OK but the field is ignored as it isn't in the schema anymore
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(
+            expected: '2026-07-01 05:06:00',
+            actual: $DB->request([
+                'SELECT' => ['date_sync'],
+                'FROM' => 'glpi_users',
+                'WHERE' => ['id' => 2],
+            ])->current()['date_sync']
+        );
+
+        $this->login();
+        ResourceAccessor::createBySchema($user_schema, ['username' => 'testuser', 'date_sync' => '2026-07-03 07:08:00'], [AdministrationController::class, 'getUserByID']);
+        $this->assertEquals(
+            expected: '2026-07-03 07:08:00',
+            actual: $DB->request([
+                'SELECT' => ['date_sync'],
+                'FROM' => 'glpi_users',
+                'WHERE' => ['name' => 'testuser'],
+            ])->current()['date_sync']
+        );
+
+        $this->login('tech', 'tech');
+        $response = ResourceAccessor::createBySchema($user_schema, ['username' => 'testuser2', 'date_sync' => '2026-07-04 08:09:00'], [AdministrationController::class, 'getUserByID']);
+        // Request is OK but the field is ignored as it isn't in the schema anymore
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals(
+            expected: null,
+            actual: $DB->request([
+                'SELECT' => ['date_sync'],
+                'FROM' => 'glpi_users',
+                'WHERE' => ['name' => 'testuser2'],
+            ])->current()['date_sync']
+        );
+
+        // Sorting by the date_sync field should be ignored for the tech user
+        $response = json_decode((string) ResourceAccessor::searchBySchema($user_schema, ['sort' => 'date_sync'])->getBody(), true);
+        $this->assertEquals("Invalid property for sorting: date_sync", $response['title']);
+
+        // Filtering by the date_sync field should be ignored for the tech user
+        $response = json_decode((string) ResourceAccessor::searchBySchema($user_schema, ['filter' => 'date_sync=gt="2040-01-01"'])->getBody(), true);
+        $this->assertGreaterThan(5, count($response));
     }
 }

--- a/tests/src/HLAPITestCase.php
+++ b/tests/src/HLAPITestCase.php
@@ -1434,4 +1434,55 @@ final class GraphQLResponseAsserter
         $this->call_asserter->test->assertTrue($found, 'GraphQL response does not contain an error with message "' . $message . '"');
         return $this;
     }
+
+    public function hasFieldAccessDenied(string $field_path, bool $exact = false): self
+    {
+        if ($exact) {
+            return $this->hasErrorWithMessage('You do not have permission to view the field ' . $field_path);
+        } else {
+            // Check for error message that contains the field path but ignoring any numeric path segments which could appear anywhere (e.g. "You do not have permission to view the field data.items.0.name")
+            // In this mode, we don't care about the numeric index within arrays
+            // Ex $field_path = 'data.items.name' would match "You do not have permission to view the field data.items.0.name" or "You do not have permission to view the field data.items.1.name"
+            $this->call_asserter->test->assertArrayHasKey('errors', $this->decoded_content, 'GraphQL response does not contain errors');
+            $found = false;
+            foreach ($this->decoded_content['errors'] as $error) {
+                if (isset($error['message']) && str_contains($error['message'], 'You do not have permission to view the field')) {
+                    // Remove any numeric segments from the error message
+                    $error_field_path = preg_replace('/\.\d+/', '', $error['message']);
+                    if ($error_field_path === 'You do not have permission to view the field ' . $field_path) {
+                        $found = true;
+                        break;
+                    }
+                }
+            }
+            $this->call_asserter->test->assertTrue($found, 'GraphQL response does not contain an error with field access denied for "' . $field_path . '"');
+            return $this;
+        }
+    }
+
+    public function hasUnknownQueryFieldError(string $field): self
+    {
+        $this->call_asserter->test->assertArrayHasKey('errors', $this->decoded_content, 'GraphQL response does not contain errors');
+        $pattern = 'Cannot query field "' . $field . '" on type "Query".';
+        foreach ($this->decoded_content['errors'] as $error) {
+            if (isset($error['message']) && str_starts_with($error['message'], $pattern)) {
+                return $this;
+            }
+        }
+        $this->call_asserter->test->fail('GraphQL response does not contain an error for unknown query field "' . $field . '"');
+    }
+
+    public function hasTypeUnknownOrAccessDeniedError(string $type): self
+    {
+        // Example: 'Unable to resolve field "SoftwareCategory": schema not found or not viewable'
+
+        $this->call_asserter->test->assertArrayHasKey('errors', $this->decoded_content, 'GraphQL response does not contain errors');
+        $pattern = 'Unable to resolve field "' . $type . '": schema not found or not viewable';
+        foreach ($this->decoded_content['errors'] as $error) {
+            if (isset($error['message']) && str_starts_with($error['message'], $pattern)) {
+                return $this;
+            }
+        }
+        $this->call_asserter->test->fail('GraphQL response does not contain an error for unknown or access denied type "' . $type . '"');
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

A concept that already partially exists in GLPI but HLAPI takes it further by centralizing the logic, shapes REST response schemas based on the permissions, and provides helpful human and machine readable GraphQL errors indicating why some of the requested fields were returned as null. Having the restrictions defined directly on the schema improves UX and reduces the chance of missing a check somewhere.

For now, the default HLAPI level checks only work with direct true/false responses to shape the schema; no SQL restrictions or item-level checks.