### PR TITLE
Prevent KB articles with children from being deleted

### DIFF
--- a/js/modules/Ajax.js
+++ b/js/modules/Ajax.js
@@ -40,10 +40,12 @@
  *   in the request body, or null if no data.
  *   Plain objects are serialized as JSON. FormData and URLSearchParams are sent
  *   as-is (form data).
+ * @param {number[]} handled_statuses - Error statuses the caller reports itself:
+ *   the response is returned instead of raising the generic error.
  * @returns {Promise<Response>} The fetch Response object.
- * @throws {Error} If the request fails or returns a non-ok status.
+ * @throws {Error} If the request fails or returns an unhandled non-ok status.
  */
-export async function post(url, values = null)
+export async function post(url, values = null, handled_statuses = [])
 {
     try {
         const is_plain_object = values !== null
@@ -69,7 +71,7 @@ export async function post(url, values = null)
         }
 
         const response = await fetch(`${CFG_GLPI.root_doc}/${url}`, params);
-        if (!response.ok) {
+        if (!response.ok && !handled_statuses.includes(response.status)) {
             throw new Error("POST request failed");
         }
 

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -691,6 +691,15 @@ export class GlpiKnowbaseArticleController
 
         const response = await deleteArticle(id);
         const body = await response.json();
+
+        if (!response.ok) {
+            glpi_alert({
+                title: __('Delete article'),
+                message: body.message,
+            });
+            return;
+        }
+
         window.location.href = body.redirect;
     }
 

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -30,7 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
-/* global _, glpi_ajax_dialog, glpi_confirm_danger, glpi_toast_error */
+/* global _, glpi_ajax_dialog, glpi_alert, glpi_confirm_danger, glpi_toast_error */
 
 import { get, post } from "/js/modules/Ajax.js";
 import { GlpiKnowbaseMoveModalController } from "/js/modules/Knowbase/MoveModalController.js";
@@ -1025,6 +1025,14 @@ export class GlpiKnowbaseAsideController
         const response = await deleteArticle(id);
         const body = await response.json();
 
+        if (!response.ok) {
+            glpi_alert({
+                title: __('Delete article'),
+                message: body.message,
+            });
+            return;
+        }
+
         // Deleting the article currently being viewed: leave the page.
         const current = this.#aside.querySelector('[data-glpi-kb-article-current]');
         if (current && parseInt(current.dataset.glpiKbArticleId) === id) {
@@ -1033,31 +1041,8 @@ export class GlpiKnowbaseAsideController
         }
 
         // Otherwise remove every entry for this article (tree + favorites) in
-        // place. A tree entry may nest child articles inside its own <li>
-        // (recursive tree), and those children are NOT deleted server-side:
-        // on reload the Builder promotes any article left without a visible
-        // parent up to the root. Mirror that here so children don't vanish
-        // until reload — reparent them to the root <ul> before removing the
-        // deleted node, unless they remain reachable under another parent.
-        const tree = this.#aside.querySelector('[data-glpi-kb-aside-tree]');
-        const root_list = tree ? tree.querySelector(':scope > ul') : null;
-
+        // place.
         for (const entry of this.#aside.querySelectorAll(`[data-glpi-kb-article-id="${CSS.escape(id)}"]`)) {
-            const child_list = entry.querySelector(':scope > ul');
-            if (child_list && root_list) {
-                for (const child of [...child_list.querySelectorAll(':scope > [data-glpi-kb-article-id]')]) {
-                    const child_id = child.dataset.glpiKbArticleId;
-                    // Still reachable under another (non-deleted) parent
-                    // elsewhere in the tree? Then it stays there; promoting it
-                    // would duplicate it, and on reload it would not be a root.
-                    const still_reachable = [...this.#aside.querySelectorAll(
-                        `[data-glpi-kb-aside-tree] [data-glpi-kb-article-id="${CSS.escape(child_id)}"]`
-                    )].some(el => !entry.contains(el));
-                    if (!still_reachable) {
-                        root_list.appendChild(child);
-                    }
-                }
-            }
             entry.remove();
         }
 

--- a/js/modules/Knowbase/EditorActions.js
+++ b/js/modules/Knowbase/EditorActions.js
@@ -131,14 +131,14 @@ export function toggleField(id, field, value)
 }
 
 /**
- * Delete an article.
+ * Delete an article. A 409 carries the reason the server refused it.
  *
  * @param {number} id
  * @returns {Promise<Response>}
  */
 export function deleteArticle(id)
 {
-    return post(`Knowbase/KnowbaseItem/${id}/Delete`, {});
+    return post(`Knowbase/KnowbaseItem/${id}/Delete`, {}, [409]);
 }
 
 /**

--- a/src/Glpi/Controller/Knowbase/DeleteArticleController.php
+++ b/src/Glpi/Controller/Knowbase/DeleteArticleController.php
@@ -36,6 +36,8 @@ namespace Glpi\Controller\Knowbase;
 
 use Glpi\Controller\AbstractController;
 use Glpi\Controller\CrudControllerTrait;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
 use KnowbaseItem;
 use Session;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -56,7 +58,27 @@ final class DeleteArticleController extends AbstractController
     )]
     public function __invoke(int $id): Response
     {
-        $this->delete(KnowbaseItem::class, $id);
+        $article = new KnowbaseItem();
+        if (!$article->getFromDB($id)) {
+            throw new NotFoundHttpException();
+        }
+
+        // Note: duplicated by the $this->purge call later but necessary to
+        // avoid disclosing information about child articles to someone that
+        // doesn't have the required rights.
+        if (!$article->can($id, PURGE)) {
+            throw new AccessDeniedHttpException();
+        }
+
+        if ($article->hasChildrenWithoutOtherParent()) {
+            return new JsonResponse([
+                'success' => false,
+                // Rendered as HTML by `glpi_alert()`.
+                'message' => \htmlescape(KnowbaseItem::getChildrenDeletionRefusalMessage()),
+            ], Response::HTTP_CONFLICT);
+        }
+
+        $this->purge(KnowbaseItem::class, $id);
         Session::addMessageAfterRedirect(__s('Item successfully deleted.'));
 
         return new JsonResponse([

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -664,15 +664,20 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             return false;
         }
 
+        if ($this->hasChildrenWithoutOtherParent()) {
+            Session::addMessageAfterRedirect(
+                msg: htmlescape(self::getChildrenDeletionRefusalMessage()),
+                message_type: ERROR,
+            );
+
+            return false;
+        }
+
         return parent::pre_deleteItem();
     }
 
     public function cleanDBonPurge()
     {
-        // Collect the children that this purge would leave outside the tree
-        // before their links to the purged article are removed below.
-        $orphaned_children = $this->getChildrenWithoutOtherParent();
-
         $this->deleteChildrenAndRelationsFromDb(
             [
                 Entity_KnowbaseItem::class,
@@ -693,10 +698,6 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             ['knowbaseitems_id_parent' => $this->fields['id']]
         );
 
-        // Attach the children that just lost their only parent back to the root
-        // article, so the knowledge base always is a single tree.
-        self::attachToRootArticle($orphaned_children);
-
         // KnowbaseItem_Comment does not extends CommonDBConnexity
         $kbic = new KnowbaseItem_Comment();
         $kbic->deleteByCriteria(['knowbaseitems_id' => $this->fields['id']]);
@@ -706,23 +707,30 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
         $kbir->deleteByCriteria(['knowbaseitems_id' => $this->fields['id']]);
     }
 
+    public static function getChildrenDeletionRefusalMessage(): string
+    {
+        return __('This article cannot be deleted because it contains sub-articles. They must be moved or deleted first.');
+    }
+
     /**
-     * Ids of the children of the loaded article that have no other parent, and
+     * Whether the loaded article has children that have no other parent, and
      * would thus be left outside the knowledge base tree if the article is
      * removed from it.
-     *
-     * @return int[]
      */
-    private function getChildrenWithoutOtherParent(): array
+    public function hasChildrenWithoutOtherParent(): bool
     {
+        if ($this->isNewItem()) {
+            throw new LogicException('The article must be loaded from the database.');
+        }
+
         $relation = new KnowbaseItem_KnowbaseItem();
 
         $children_ids = array_map('intval', array_column(
-            $relation->find(['knowbaseitems_id_parent' => $this->fields['id']]),
+            $relation->find(['knowbaseitems_id_parent' => $this->getID()]),
             'knowbaseitems_id'
         ));
         if ($children_ids === []) {
-            return [];
+            return false;
         }
 
         $parents_count = array_count_values(array_map('intval', array_column(
@@ -730,36 +738,13 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             'knowbaseitems_id'
         )));
 
-        return array_values(array_filter(
-            $children_ids,
-            static fn(int $child_id): bool => ($parents_count[$child_id] ?? 0) <= 1,
-        ));
-    }
-
-    /**
-     * Attach the given articles to the root article, ignoring the ones that
-     * can not have a parent.
-     *
-     * @param int[] $article_ids
-     */
-    private static function attachToRootArticle(array $article_ids): void
-    {
-        if ($article_ids === [] || !self::hasRoot()) {
-            return;
-        }
-
-        $root_id  = self::getRootId();
-        $relation = new KnowbaseItem_KnowbaseItem();
-        foreach ($article_ids as $article_id) {
-            if ($article_id === $root_id) {
-                continue;
+        foreach ($children_ids as $child_id) {
+            if (($parents_count[$child_id] ?? 0) <= 1) {
+                return true;
             }
-
-            $relation->add([
-                'knowbaseitems_id'        => $article_id,
-                'knowbaseitems_id_parent' => $root_id,
-            ]);
         }
+
+        return false;
     }
 
     /**

--- a/tests/e2e/specs/Knowbase/kb-aside-actions.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-actions.spec.ts
@@ -204,3 +204,79 @@ test('Can delete an article from the aside dots menu without leaving the page', 
     await expect(kb.getAsideTreeArticleRow(target_id)).toHaveCount(0);
     await expect(page).toHaveURL(new RegExp(`knowbaseitem\\.form\\.php\\?id=${viewed_id}(\\D|$)`));
 });
+
+test("Can't delete an article with children", async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const parent_name = getUniqueName(`Aside undeletable parent`);
+    const parent_id = await api.createItem('KnowbaseItem', {
+        name: parent_name,
+        answer: 'Parent content',
+        entities_id: getWorkerEntityId(),
+    });
+    const child_name = getUniqueName(`Aside undeletable child`);
+    const child_id = await api.createItem('KnowbaseItem', {
+        name: child_name,
+        answer: 'Child content',
+        entities_id: getWorkerEntityId(),
+        _parents: [parent_id],
+    });
+
+    // Viewing the child unfolds the path to it, so both rows are on screen.
+    await kb.goto(child_id);
+    await expect(kb.getAsideCategoryArticle(parent_name, child_name)).toBeVisible();
+
+    // The action is offered on the parent, and the server explains the refusal:
+    // deleting it would leave the child outside the tree.
+    await kb.doOpenAsideArticleMenu(parent_id);
+    await kb.getAsideArticleAction(parent_id, 'Delete article').click();
+    await page.getByRole('dialog')
+        .getByRole('button', { name: 'Delete', exact: true })
+        .click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toContainText(
+        'This article cannot be deleted because it contains sub-articles. They must be moved or deleted first.'
+    );
+
+    // Nothing was deleted.
+    await dialog.getByRole('button', { name: 'OK' }).click();
+    await expect(dialog).toBeHidden();
+    await expect(kb.getAsideTreeArticleRow(parent_id)).toBeVisible();
+    await expect(kb.getAsideTreeArticleRow(child_id)).toBeVisible();
+});
+
+test('An article can be deleted right after its last child was deleted', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const viewed_id = await api.knowbase.createArticle({
+        name: getUniqueName(`Aside viewed`),
+        answer: 'My answer',
+    });
+    const parent_name = getUniqueName(`Aside emptied parent`);
+    const parent_id = await api.createItem('KnowbaseItem', {
+        name: parent_name,
+        answer: 'Parent content',
+        entities_id: getWorkerEntityId(),
+    });
+    const child_id = await api.createItem('KnowbaseItem', {
+        name: getUniqueName(`Aside emptied child`),
+        answer: 'Child content',
+        entities_id: getWorkerEntityId(),
+        _parents: [parent_id],
+    });
+
+    // Delete the only child
+    await kb.goto(viewed_id);
+    await kb.doExpandAsideCategory(parent_name);
+    await kb.doOpenAsideArticleMenu(child_id);
+    await kb.doDeleteAsideArticle(child_id);
+    await expect(kb.getAsideTreeArticleRow(child_id)).toHaveCount(0);
+
+    // Now delete the parent
+    await kb.doOpenAsideArticleMenu(parent_id);
+    await kb.doDeleteAsideArticle(parent_id);
+    await expect(kb.getAsideTreeArticleRow(parent_id)).toHaveCount(0);
+});

--- a/tests/functional/Glpi/Controller/Knowbase/DeleteArticleControllerTest.php
+++ b/tests/functional/Glpi/Controller/Knowbase/DeleteArticleControllerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Controller\Knowbase;
+
+use Glpi\Controller\Knowbase\DeleteArticleController;
+use Glpi\Tests\DbTestCase;
+use KnowbaseItem;
+use Symfony\Component\HttpFoundation\Response;
+
+class DeleteArticleControllerTest extends DbTestCase
+{
+    private function callController(int $id): Response
+    {
+        return (new DeleteArticleController())->__invoke($id);
+    }
+
+    private function makeArticle(array $parents = []): int
+    {
+        $input = [
+            'name'         => 'Delete article ' . $this->getUniqueString(),
+            'answer'       => '<p>x</p>',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ];
+        if ($parents !== []) {
+            $input['_parents'] = $parents;
+        }
+
+        return $this->createItem(KnowbaseItem::class, $input)->getID();
+    }
+
+    public function testChildlessArticleSucceeds(): void
+    {
+        $this->login();
+        $this->setEntity(0, true);
+        $id = $this->makeArticle();
+
+        $response = $this->callController($id);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertFalse((new KnowbaseItem())->getFromDB($id));
+    }
+
+    public function testDeletingAnArticleThatHasChildrenFails(): void
+    {
+        $this->login();
+        $this->setEntity(0, true);
+        $parent_id = $this->makeArticle();
+        $child_id  = $this->makeArticle([$parent_id]);
+
+        $response = $this->callController($parent_id);
+
+        $this->assertSame(Response::HTTP_CONFLICT, $response->getStatusCode());
+        $this->assertSame(
+            [
+                'success' => false,
+                'message' => 'This article cannot be deleted because it contains sub-articles. They must be moved or deleted first.',
+            ],
+            json_decode((string) $response->getContent(), true),
+        );
+
+        // Both articles are untouched.
+        $this->assertTrue((new KnowbaseItem())->getFromDB($parent_id));
+        $this->assertTrue((new KnowbaseItem())->getFromDB($child_id));
+    }
+}

--- a/tests/functional/KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItemTest.php
@@ -2979,38 +2979,123 @@ HTML,
         $this->assertSame([$root_id], $this->getParentIds($child->getID()));
     }
 
-    public function testPurgingAnArticleAttachesItsOrphanedChildrenToTheRoot(): void
+    public function testDeletingAnArticleIsRefusedWhenItWouldDetachAChild(): void
     {
         $this->login();
-        $root_id = KnowbaseItem::getRootId();
+        $this->setEntity(0, true);
 
         $parent = $this->createItem(KnowbaseItem::class, [
-            'name'   => 'Parent ' . __FUNCTION__,
-            'answer' => '',
+            'name'         => 'Parent ' . __FUNCTION__,
+            'answer'       => '',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+        $child = $this->createItem(KnowbaseItem::class, [
+            'name'         => 'Only child ' . __FUNCTION__,
+            'answer'       => '',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+            '_parents'     => [$parent->getID()],
+        ]);
+
+        // Deletion rights are untouched: the refusal is about the tree, not
+        // about what the user is allowed to do.
+        $this->assertTrue($parent->canDeleteItem());
+        $this->assertTrue($parent->canPurgeItem());
+
+        // The action is still offered: the refusal is decided when it is used,
+        // so that it never rests on what the page was rendered with.
+        $this->assertContains(
+            EditorActionType::DELETE_ARTICLE,
+            $this->getAsideActionTypes($parent),
+        );
+
+        // Every deletion path goes through the model, which refuses.
+        $expected_message = 'This article cannot be deleted because it contains sub-articles. They must be moved or deleted first.';
+        $this->assertFalse($parent->delete(['id' => $parent->getID()]));
+        $this->hasSessionMessages(ERROR, [$expected_message]);
+        $this->assertFalse($parent->delete(['id' => $parent->getID()], true));
+        $this->hasSessionMessages(ERROR, [$expected_message]);
+
+        // Nothing moved: the child is still attached to its parent, and both
+        // articles are still there.
+        $this->assertTrue($parent->getFromDB($parent->getID()));
+        $this->assertTrue($child->getFromDB($child->getID()));
+        $this->assertSame([$parent->getID()], $this->getParentIds($child->getID()));
+    }
+
+    public function testDeletingAnArticleIsAllowedWhenItsChildrenHaveAnotherParent(): void
+    {
+        $this->login();
+        $this->setEntity(0, true);
+
+        $parent = $this->createItem(KnowbaseItem::class, [
+            'name'         => 'Parent ' . __FUNCTION__,
+            'answer'       => '',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
         ]);
         $other_parent = $this->createItem(KnowbaseItem::class, [
-            'name'   => 'Other parent ' . __FUNCTION__,
-            'answer' => '',
-        ]);
-        $only_child = $this->createItem(KnowbaseItem::class, [
-            'name'     => 'Only child ' . __FUNCTION__,
-            'answer'   => '',
-            '_parents' => [$parent->getID()],
+            'name'         => 'Other parent ' . __FUNCTION__,
+            'answer'       => '',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
         ]);
         $shared_child = $this->createItem(KnowbaseItem::class, [
-            'name'     => 'Shared child ' . __FUNCTION__,
-            'answer'   => '',
-            '_parents' => [$parent->getID(), $other_parent->getID()],
+            'name'         => 'Shared child ' . __FUNCTION__,
+            'answer'       => '',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+            '_parents'     => [$parent->getID(), $other_parent->getID()],
         ]);
 
+        // The child would not leave the tree, so nothing stands in the way.
         $this->assertTrue($parent->delete(['id' => $parent->getID()], true));
 
-        // The child that just lost its only parent is kept in the tree, under
-        // the root article, instead of becoming a second root.
-        $this->assertSame([$root_id], $this->getParentIds($only_child->getID()));
-
-        // The one that still has a parent is left alone.
+        // The child is left alone, under its remaining parent.
         $this->assertSame([$other_parent->getID()], $this->getParentIds($shared_child->getID()));
+    }
+
+    public function testDeletingChildlessArticleIsAllowed(): void
+    {
+        $this->login();
+        $this->setEntity(0, true);
+
+        $article = $this->createItem(KnowbaseItem::class, [
+            'name'         => 'Article ' . __FUNCTION__,
+            'answer'       => '',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+
+        $this->assertTrue($article->delete(['id' => $article->getID()], true));
+    }
+
+    public function testAnArticleBecomesDeletableAsSoonAsItsLastChildIsGone(): void
+    {
+        $this->login();
+        $this->setEntity(0, true);
+
+        $parent = $this->createItem(KnowbaseItem::class, [
+            'name'         => 'Parent ' . __FUNCTION__,
+            'answer'       => '',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+        $child = $this->createItem(KnowbaseItem::class, [
+            'name'         => 'Only child ' . __FUNCTION__,
+            'answer'       => '',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+            '_parents'     => [$parent->getID()],
+        ]);
+
+        $this->assertTrue($parent->hasChildrenWithoutOtherParent());
+        $this->assertTrue($child->delete(['id' => $child->getID()], true));
+
+        // No reload stands between the two deletions: the parent is a leaf now.
+        $this->assertFalse($parent->hasChildrenWithoutOtherParent());
+        $this->assertTrue($parent->delete(['id' => $parent->getID()], true));
     }
 
     /**


### PR DESCRIPTION
Allow articles with sub-articles is a bit of a mess from the UI/UX standpoint (article must have a new parent in this case, which change their visibility among others things).

I've prevented this by making sure articles with children can't be deleted directly. Users need to explicitly move or delete the children before they are allowed to delete the article.