### PR TITLE
Fix API search warning on additional fields with TABLE prefix

### DIFF
--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -1813,6 +1813,10 @@ abstract class API
                     $tmp_fields = [$col_ref_field => $current_values];
                     if (array_key_exists('additionalfields', $col['searchopt'])) {
                         foreach ($col['searchopt']['additionalfields'] as $field_name) {
+                            // The search engine removes the `TABLE.` prefix from the column alias
+                            if (str_starts_with($field_name, 'TABLE.')) {
+                                $field_name = substr($field_name, strlen('TABLE.'));
+                            }
                             $field_value_key = 'ITEM_' . $col['itemtype'] . '_' . $col['id'] . '_' . $field_name;
                             $tmp_fields[$field_name] = $raw[$field_value_key];
                         }

--- a/tests/web/APIRestTest.php
+++ b/tests/web/APIRestTest.php
@@ -487,6 +487,29 @@ class APIRestTest extends TestCase
         $this->checkEmptyContentRange($data, $data['headers']);
     }
 
+    public function testSearchWithTableAdditionalField()
+    {
+        // Search option 62 of tickets (satisfaction) has `TABLE.entities_id` as additional field.
+        // No warning should be logged on the server, see `tearDown()`.
+        $data = $this->query(
+            'search',
+            [
+                'itemtype' => 'Ticket',
+                'headers'  => ['Session-Token' => $this->session_token],
+                'query'    => [
+                    'forcedisplay' => [62],
+                ],
+            ]
+        );
+
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('data', $data);
+        $this->assertNotEmpty($data['data']);
+        foreach ($data['data'] as $row) {
+            $this->assertArrayHasKey(62, $row);
+        }
+    }
+
     public function testSearchAllAssets()
     {
         // Test that searching AllAssets (itemtype without database table) doesn't crash


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #24699

The search engine removes the `TABLE.` prefix of additional fields when building the column alias, but the API was building the key with the prefix, so every row of a search with `forcedisplay=62` on tickets logged an "Undefined array key" warning.
