### PR TITLE
Use reminder translations in the planning

### DIFF
--- a/src/Glpi/Features/PlanningEvent.php
+++ b/src/Glpi/Features/PlanningEvent.php
@@ -680,6 +680,18 @@ trait PlanningEvent
             $events += $events_toadd;
         }
 
+        return static::translatePlanningEvents($events);
+    }
+
+    /**
+     * Apply the translations of the current language to the planning events.
+     *
+     * @param array<array<string, mixed>> $events
+     *
+     * @return array<array<string, mixed>>
+     */
+    protected static function translatePlanningEvents(array $events): array
+    {
         return $events;
     }
 

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -52,6 +52,7 @@ class Reminder extends CommonDBVisible implements
 {
     use PlanningEvent {
         post_getEmpty as trait_post_getEmpty;
+        populatePlanning as trait_populatePlanning;
     }
     use VobjectConverterTrait;
     /** @use Clonable<static> */
@@ -565,6 +566,49 @@ class Reminder extends CommonDBVisible implements
             'parent_link' => $parent->getLink(['icon' => true, 'forceid' => true]),
             'parent_entity_badge' => Entity::badgeCompletenameById($parent->getEntityID()),
         ]);
+    }
+
+    public static function populatePlanning($options = []): array
+    {
+        global $DB;
+
+        $events = self::trait_populatePlanning($options);
+
+        $language = $_SESSION['glpilanguage'] ?? null;
+        $reminders_ids = array_unique(array_column($events, 'reminders_id'));
+        if (empty($language) || $reminders_ids === []) {
+            return $events;
+        }
+
+        // Use the translations of the current language, if any
+        $translations = [];
+        $iterator = $DB->request([
+            'SELECT' => ['reminders_id', 'name', 'text'],
+            'FROM'   => ReminderTranslation::getTable(),
+            'WHERE'  => [
+                'reminders_id' => $reminders_ids,
+                'language'     => $language,
+            ],
+        ]);
+        foreach ($iterator as $data) {
+            $translations[$data['reminders_id']] = $data;
+        }
+
+        foreach ($events as &$event) {
+            $translation = $translations[$event['reminders_id'] ?? 0] ?? null;
+            if ($translation === null) {
+                continue;
+            }
+            if (!empty($translation['name'])) {
+                $event['name'] = $translation['name'];
+            }
+            if (!empty($translation['text'])) {
+                $event['text'] = RichText::getSafeHtml($translation['text']);
+            }
+        }
+        unset($event);
+
+        return $events;
     }
 
     final public static function getListCriteria(): array

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -52,7 +52,6 @@ class Reminder extends CommonDBVisible implements
 {
     use PlanningEvent {
         post_getEmpty as trait_post_getEmpty;
-        populatePlanning as trait_populatePlanning;
     }
     use VobjectConverterTrait;
     /** @use Clonable<static> */
@@ -568,11 +567,14 @@ class Reminder extends CommonDBVisible implements
         ]);
     }
 
-    public static function populatePlanning($options = []): array
+    /**
+     * @param array<array<string, mixed>> $events
+     *
+     * @return array<array<string, mixed>>
+     */
+    protected static function translatePlanningEvents(array $events): array
     {
         global $DB;
-
-        $events = self::trait_populatePlanning($options);
 
         $language = $_SESSION['glpilanguage'] ?? null;
         $reminders_ids = array_unique(array_column($events, 'reminders_id'));

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -582,7 +582,10 @@ class Reminder extends CommonDBVisible implements
             return $events;
         }
 
-        // Use the translations of the current language, if any
+        // Use the translations of the current language, if any.
+        // Order by id and keep the first row for each reminder, so that the
+        // result is deterministic and matches `ReminderTranslation::getTranslatedValue()`
+        // when several rows exist for the same reminder and language.
         $translations = [];
         $iterator = $DB->request([
             'SELECT' => ['reminders_id', 'name', 'text'],
@@ -591,9 +594,12 @@ class Reminder extends CommonDBVisible implements
                 'reminders_id' => $reminders_ids,
                 'language'     => $language,
             ],
+            'ORDER'  => 'id',
         ]);
         foreach ($iterator as $data) {
-            $translations[$data['reminders_id']] = $data;
+            if (!isset($translations[$data['reminders_id']])) {
+                $translations[$data['reminders_id']] = $data;
+            }
         }
 
         foreach ($events as &$event) {

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -226,10 +226,13 @@ TWIG, $twig_params);
     public static function getTranslatedValue(Reminder $item, $field = "name")
     {
         $obj   = new self();
-        $found = $obj->find([
-            'reminders_id'   => $item->getID(),
-            'language'           => $_SESSION['glpilanguage'],
-        ]);
+        $found = $obj->find(
+            [
+                'reminders_id'   => $item->getID(),
+                'language'           => $_SESSION['glpilanguage'],
+            ],
+            ['id ASC']
+        );
 
         if (
             (count($found) > 0)

--- a/tests/functional/ReminderTranslationTest.php
+++ b/tests/functional/ReminderTranslationTest.php
@@ -98,9 +98,9 @@ class ReminderTranslationTest extends DbTestCase
         $this->assertGreaterThan(0, (int) $translation->add([
             'reminders_id' => $reminders_id,
             'users_id'     => \Session::getLoginUserID(),
-            'language'     => 'fr_FR',
-            'name'         => 'Titre traduit',
-            'text'         => '<p>Texte traduit</p>',
+            'language'     => 'ja_JP',
+            'name'         => 'Translated title',
+            'text'         => '<p>Translated text</p>',
         ]));
 
         $get_event = function () use ($reminders_id): array {
@@ -127,11 +127,30 @@ class ReminderTranslationTest extends DbTestCase
         $this->assertStringContainsString('Original text', $event['text']);
 
         // The translation for the current language is used
-        $_SESSION['glpilanguage'] = 'fr_FR';
+        $_SESSION['glpilanguage'] = 'ja_JP';
         $event = $get_event();
+        $this->assertSame('Translated title', $event['name']);
+        $this->assertStringContainsString('Translated text', $event['text']);
+
+        // With several rows for the same reminder and language, the planning must
+        // pick the same one as `getTranslatedValue()` (the first, ordered by id).
+        $this->assertGreaterThan(0, (int) (new \ReminderTranslation())->add([
+            'reminders_id' => $reminders_id,
+            'users_id'     => \Session::getLoginUserID(),
+            'language'     => 'ja_JP',
+            'name'         => 'Second translated title',
+            'text'         => '<p>Second translated text</p>',
+        ]));
+
+        $reminder1 = new \Reminder();
+        $this->assertTrue($reminder1->getFromDB($reminders_id));
+
+        $event = $get_event();
+        // Read the single-item value under the same language before restoring it.
+        $single_value = \ReminderTranslation::getTranslatedValue($reminder1, 'name');
         $_SESSION['glpilanguage'] = $current_lang;
-        $this->assertSame('Titre traduit', $event['name']);
-        $this->assertStringContainsString('Texte traduit', $event['text']);
+        $this->assertSame($single_value, $event['name']);
+        $this->assertSame('Translated title', $event['name']);
     }
 
     /**

--- a/tests/functional/ReminderTranslationTest.php
+++ b/tests/functional/ReminderTranslationTest.php
@@ -77,6 +77,63 @@ class ReminderTranslationTest extends DbTestCase
         $this->assertSame($text_fr, $text);
     }
 
+    public function testPlanningUsesTranslation(): void
+    {
+        $this->login();
+        $this->setEntity('_test_root_entity', true);
+
+        $reminder = new \Reminder();
+        $reminders_id = (int) $reminder->add([
+            'name'        => '_test_planned_reminder',
+            'text'        => '<p>Original text</p>',
+            'entities_id' => 0,
+            'plan'        => [
+                'begin' => '2025-01-15 10:00:00',
+                'end'   => '2025-01-15 11:00:00',
+            ],
+        ]);
+        $this->assertGreaterThan(0, $reminders_id);
+
+        $translation = new \ReminderTranslation();
+        $this->assertGreaterThan(0, (int) $translation->add([
+            'reminders_id' => $reminders_id,
+            'users_id'     => \Session::getLoginUserID(),
+            'language'     => 'fr_FR',
+            'name'         => 'Titre traduit',
+            'text'         => '<p>Texte traduit</p>',
+        ]));
+
+        $get_event = function () use ($reminders_id): array {
+            $events = \Reminder::populatePlanning([
+                'who'      => \Session::getLoginUserID(),
+                'whogroup' => 0,
+                'begin'    => '2025-01-15 00:00:00',
+                'end'      => '2025-01-16 00:00:00',
+            ]);
+            foreach ($events as $event) {
+                if ((int) $event['reminders_id'] === $reminders_id) {
+                    return $event;
+                }
+            }
+            $this->fail('Reminder not found in planning');
+        };
+
+        $current_lang = $_SESSION['glpilanguage'];
+
+        // No translation for the current language, the original values are used
+        $_SESSION['glpilanguage'] = 'en_GB';
+        $event = $get_event();
+        $this->assertSame('_test_planned_reminder', $event['name']);
+        $this->assertStringContainsString('Original text', $event['text']);
+
+        // The translation for the current language is used
+        $_SESSION['glpilanguage'] = 'fr_FR';
+        $event = $get_event();
+        $_SESSION['glpilanguage'] = $current_lang;
+        $this->assertSame('Titre traduit', $event['name']);
+        $this->assertStringContainsString('Texte traduit', $event['text']);
+    }
+
     /**
      * Add translation into database
      *


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #24801

Reminder translations were only used in the reminders lists of the home page. The planning ("Your planning" on the home page, the Planning page and its tooltips, the iCal export) is built in `PlanningEvent::populatePlanning()` from the reminder's own name and text, so it always showed the original language.

`Reminder::populatePlanning()` now replaces the name and text with the translation of the current language when there is one, using a single query for all the reminders of the planning.
