### PR TITLE
Fix - Dashboard 'Bars' widget double-wraps series data for non-distributed charts

### DIFF
--- a/src/Glpi/Dashboard/Widget.php
+++ b/src/Glpi/Dashboard/Widget.php
@@ -1111,14 +1111,20 @@ TWIG, $twig_params);
         } else {
             if ($p['distributed']) {
                 array_splice($series, $nb_labels);
+                $series = [
+                    [
+                        'data' => $series,
+                    ],
+                ];
             } else {
+                // $series is already wrapped as [[...]] by the caller (single non-distributed serie)
                 array_splice($series[0], 0, -$nb_labels);
+                $series = [
+                    [
+                        'data' => $series[0],
+                    ],
+                ];
             }
-            $series = [
-                [
-                    'data' => $series,
-                ],
-            ];
         }
 
         $nb_series = count($series);

--- a/tests/functional/Glpi/Dashboard/WidgetTest.php
+++ b/tests/functional/Glpi/Dashboard/WidgetTest.php
@@ -285,4 +285,62 @@ class WidgetTest extends DbTestCase
             Widget::getGradientPalette($bg_color, $nb_series, $revert)
         );
     }
+
+    /**
+     * Extract the `chart_options` JS variable embedded in the HTML returned by
+     * chart widgets (simpleBar/simpleLine/...) and decode it back to an array.
+     */
+    private function extractChartOptions(string $html): array
+    {
+        $this->assertMatchesRegularExpression(
+            '/const chart_options = (\{.*\});$/m',
+            $html
+        );
+        preg_match('/const chart_options = (\{.*\});$/m', $html, $matches);
+
+        return json_decode($matches[1], true);
+    }
+
+    public static function simpleBarDistributionProvider(): iterable
+    {
+        // Mirrors what Provider::ticketsOpened() returns: a single (non-multiple)
+        // bar serie, explicitly marked as non-distributed.
+        yield 'non-distributed single serie (e.g. Provider::ticketsOpened)' => [
+            'distributed' => false,
+        ];
+        // Default behaviour of Widget::simpleBar() when the provider does not
+        // force 'distributed', each bar getting its own color from the palette.
+        yield 'distributed single serie (simpleBar default)' => [
+            'distributed' => true,
+        ];
+    }
+
+    /**
+     * Regression test for the "Number of tickets by month" dashboard card
+     * displaying `undefined`/`NaN` in its "View data" table and no bars at all
+     */
+    #[DataProvider('simpleBarDistributionProvider')]
+    public function testSimpleBarSingleSerieDataIsNotDoubleWrapped(bool $distributed): void
+    {
+        $data = [
+            ['number' => 440, 'label' => '2025-09', 'url' => '/front/ticket.php?…'],
+            ['number' => 558, 'label' => '2025-10', 'url' => '/front/ticket.php?…'],
+            ['number' => 581, 'label' => '2025-11', 'url' => '/front/ticket.php?…'],
+        ];
+
+        $html = Widget::simpleBar([
+            'data'        => $data,
+            'distributed' => $distributed,
+            'label'       => 'Number of tickets by month',
+        ]);
+
+        $chart_options = $this->extractChartOptions($html);
+
+        $this->assertCount(1, $chart_options['series']);
+        $serie_data = $chart_options['series'][0]['data'];
+
+        $this->assertCount(3, $serie_data);
+        $this->assertEquals([440, 558, 581], array_column($serie_data, 'value'));
+        $this->assertEquals(['2025-09', '2025-10', '2025-11'], array_column($serie_data, 'meta'));
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !46152
- Here is a brief description of what this PR does

The "Bars" chart widget (e.g. the "Number of tickets by month" dashboard card) rendered no bars at all, and its "View data" table showed `NaN` on the first row and `undefined` on every other row.

`Widget::simpleBar()` wraps its series data in an array when `distributed` is `false`. `Widget::getBarsGraph()` then wrapped that already-wrapped array a second time, so ECharts ended up with a single data point (an array of 12 months) instead of 12 separate data points.

`Provider::ticketsOpened()` (used by the "Number of tickets by month" card) explicitly sets `distributed => false`, which is what triggers this path and makes the bug visible on that specific card.

## Screenshots (if appropriate):

### Before

**Graph** : 
<img width="673" height="403" alt="image" src="https://github.com/user-attachments/assets/a22a0d3c-5258-4f2c-8cb5-57dbb778a3ed" />


**Datas** : 
<img width="673" height="403" alt="image" src="https://github.com/user-attachments/assets/574425d2-617a-4b9c-ae85-15986a0270a6" />


### After

**Graph** : 
<img width="673" height="403" alt="image" src="https://github.com/user-attachments/assets/5c5aa7fe-71ee-4e98-9fa7-e4e792cfdb4e" />

**Datas** : 
<img width="673" height="403" alt="image" src="https://github.com/user-attachments/assets/b15197d6-b060-4a7c-a847-9fb296b7590a" />
