### PR TITLE
fix select2 exact-match and rebuild races in item.spec.ts

### DIFF
--- a/tests/e2e/pages/FormPage.ts
+++ b/tests/e2e/pages/FormPage.ts
@@ -119,7 +119,7 @@ export class FormPage extends GlpiPage
             dropdown,
             type,
             () => this.doSetDropdownValue(dropdown, type, false),
-            'glpi-form-editor-question-type-changed'
+            'glpi-form-editor-question-sub-type-changed'
         );
     }
 

--- a/tests/e2e/pages/FormPage.ts
+++ b/tests/e2e/pages/FormPage.ts
@@ -103,31 +103,123 @@ export class FormPage extends GlpiPage
 
     public async setQuestionType(question: Locator, type: string): Promise<void>
     {
-        await this.doSetDropdownValue(
-            this.getDropdownByLabel('Question type', question)
-                .filter({visible : true}),
+        const dropdown = this.getDropdownByLabel('Question type', question).filter({visible : true});
+        await this.runActionAndWaitForEditorEvent(
+            dropdown,
             type,
-            false
+            () => this.doSetDropdownValue(dropdown, type, false),
+            'glpi-form-editor-question-type-changed'
         );
     }
 
     public async setSubQuestionType(question: Locator, type: string): Promise<void>
     {
-        await this.doSetDropdownValue(
-            this.getDropdownByLabel('Question sub type', question)
-                .filter({visible : true}),
+        const dropdown = this.getDropdownByLabel('Question sub type', question).filter({visible : true});
+        await this.runActionAndWaitForEditorEvent(
+            dropdown,
             type,
-            false
+            () => this.doSetDropdownValue(dropdown, type, false),
+            'glpi-form-editor-question-type-changed'
         );
     }
 
-    public async setItemTypeForItemQuestion(question: Locator, item_type: string): Promise<void>
+    public async setItemTypeForItemQuestion(question: Locator, item_type: string, exact: boolean = false): Promise<void>
     {
-        await this.doSetDropdownValue(
-            this.getDropdownByLabel('Select an itemtype', question)
-                .filter({visible : true}),
+        const type_dropdown = this.getDropdownByLabel('Select an itemtype', question).filter({visible : true});
+        await this.runAndWaitForDefaultValueRebuild(
+            type_dropdown,
             item_type,
-            false
+            () => this.doSetDropdownValue(type_dropdown, item_type, exact),
+            this.getDropdownByLabel('Select an item', question).filter({visible : true})
+        );
+    }
+
+    public async setDropdownQuestionType(question: Locator, type: string): Promise<void>
+    {
+        const type_dropdown = this.getDropdownByLabel('Select a dropdown type', question).filter({visible : true});
+        await this.runAndWaitForDefaultValueRebuild(
+            type_dropdown,
+            type,
+            () => this.doSetDropdownValue(type_dropdown, type),
+            this.getDropdownByLabel('Select a dropdown item', question).filter({visible : true})
+        );
+    }
+
+    /**
+     * Type changes rebuild the default value combobox via AJAX with no completion
+     * event (QuestionItem.js), so wait for the old widget to detach. Skip if
+     * target_value is already selected: nothing would rebuild.
+     */
+    private async runAndWaitForDefaultValueRebuild(
+        type_dropdown: Locator,
+        target_value: string,
+        action: () => Promise<void>,
+        stale_default_value_dropdown: Locator,
+    ): Promise<void>
+    {
+        const current_text = (await type_dropdown.textContent()) ?? '';
+        if (current_text.includes(target_value)) {
+            await action();
+            return;
+        }
+
+        // elementHandle() waits for the element; count() doesn't and would race the render.
+        const stale_handle = await stale_default_value_dropdown.elementHandle({timeout: 5000}).catch(() => null);
+
+        await action();
+
+        if (stale_handle !== null) {
+            await stale_handle.evaluate((el) => new Promise<void>((resolve) => {
+                if (!el.isConnected) {
+                    resolve();
+                    return;
+                }
+                const observer = new MutationObserver(() => {
+                    if (!el.isConnected) {
+                        observer.disconnect();
+                        resolve();
+                    }
+                });
+                observer.observe(document.body, {childList: true, subtree: true});
+            }));
+            await stale_handle.dispose();
+        }
+    }
+
+    /**
+     * Category changes rebuild option lists after an AJAX call, signaled only via
+     * a jQuery-only event (invisible to addEventListener). Skip if target_value is
+     * already selected: nothing would fire.
+     */
+    private async runActionAndWaitForEditorEvent(
+        dropdown: Locator,
+        target_value: string,
+        action: () => Promise<void>,
+        event_name: string,
+    ): Promise<void>
+    {
+        const current_text = (await dropdown.textContent()) ?? '';
+        if (current_text.includes(target_value)) {
+            await action();
+            return;
+        }
+
+        const marker = `__glpi_e2e_${event_name.replace(/[^a-zA-Z0-9]/g, '_')}`;
+
+        await this.page.evaluate(([marker, event_name]) => {
+            type JQueryLike = (target: Document) => {one: (event: string, handler: () => void) => void};
+            const jq = (window as unknown as {jQuery: JQueryLike}).jQuery;
+            (window as unknown as Record<string, boolean>)[marker] = false;
+            jq(document).one(event_name, () => {
+                (window as unknown as Record<string, boolean>)[marker] = true;
+            });
+        }, [marker, event_name] as [string, string]);
+
+        await action();
+
+        await this.page.waitForFunction(
+            (marker) => (window as unknown as Record<string, boolean>)[marker] === true,
+            marker
         );
     }
 

--- a/tests/e2e/specs/Form/QuestionTypes/item.spec.ts
+++ b/tests/e2e/specs/Form/QuestionTypes/item.spec.ts
@@ -106,11 +106,7 @@ test.describe('Item form question type', () => {
         const question = form.getLastQuestion();
         await question.click({ position: { x: 0, y: 0 } });
 
-        await form.doSetDropdownValue(
-            form.getDropdownByLabel('Select an itemtype', question)
-                .filter({ visible: true }),
-            'Tickets'
-        );
+        await form.setItemTypeForItemQuestion(question, 'Tickets', true);
 
         await form.doSetDropdownValue(
             form.getDropdownByLabel('Select an item', question)
@@ -140,12 +136,8 @@ test.describe('Item form question type', () => {
         const question = form.getLastQuestion();
         await question.click({ position: { x: 0, y: 0 } });
         
-        await form.doSetDropdownValue(
-            form.getDropdownByLabel('Select an itemtype', question)
-                .filter({ visible: true }),
-            'Tickets'
-        );
-        
+        await form.setItemTypeForItemQuestion(question, 'Tickets', true);
+
         await form.doEnableMultipleDropdownMode(question);
 
         await form.doSetDropdownValue(
@@ -175,25 +167,15 @@ test.describe('Item form question type', () => {
         await question.click({ position: { x: 0, y: 0 } });
 
         await form.setSubQuestionType(question, 'Dropdowns');
-        await form.doSetDropdownValue(
-            form.getDropdownByLabel('Select a dropdown type', question)
-                .filter({ visible: true }),
-            'ITIL categories'
-        );
+        await form.setDropdownQuestionType(question, 'ITIL categories');
 
-        // Select the new ITIL category as default value.
-        // Tree dropdowns may display the same value multiple times (with a
-        // "»" depth prefix), so the first matching option is used.
+        // This is a remote (ajax-type) select2 dropdown: it only loads real options
+        // once queried, so the search term must be typed to trigger that query
+        // (see itilcategory.spec.ts, which does the same for the same widget kind).
         const item_dropdown = form
             .getDropdownByLabel('Select a dropdown item', question)
             .filter({ visible: true });
-        await item_dropdown.click();
-        await form.page
-            .getByRole('listbox')
-            .getByRole('option', { name: 'Test ITIL category' })
-            .first()
-            .click();
-        await expect(item_dropdown).toContainText('Test ITIL category');
+        await form.doSearchAndClickDropdownValue(item_dropdown, 'Test ITIL category');
 
         // Save and check the default value is set in the preview
         await form.doSaveFormEditor();


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

- Here is a brief description of what this PR does : Since the select2 version bump changed its markup, a loose selector added in PR #24081 started colliding with another test's leftover data, [causing the CI failure
](https://github.com/glpi-project/glpi/actions/runs/34482604730?pr=25450) 

Also found two more dropdown race conditions in the same file. Fixed the selector and added proper waits for both races. 

