### PR TITLE
Fix knowledge base aside renaming all nested articles

### DIFF
--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -578,11 +578,17 @@ export class GlpiKnowbaseArticleController
         }
 
         const aside = document.querySelector('[data-main-page-aside="knowbaseitem"]');
-        const entries = aside.querySelectorAll(
-            `[data-glpi-kb-article-id="${CSS.escape(String(this.#item_id))}"] [data-glpi-kb-article-title]`
+        const articles = aside.querySelectorAll(
+            `[data-glpi-kb-article-id="${CSS.escape(String(this.#item_id))}"]`
         );
-        for (const entry of entries) {
-            entry.textContent = title;
+        for (const article of articles) {
+            for (const entry of article.querySelectorAll('[data-glpi-kb-article-title]')) {
+                // Child articles are nested inside this article's element, so only
+                // update the title that belongs to this article and not its children.
+                if (entry.closest('[data-glpi-kb-article-id]') === article) {
+                    entry.textContent = title;
+                }
+            }
         }
     }
 
@@ -597,22 +603,29 @@ export class GlpiKnowbaseArticleController
         }
 
         const aside = document.querySelector('[data-main-page-aside="knowbaseitem"]');
-        const containers = aside.querySelectorAll(
-            `[data-glpi-kb-article-id="${CSS.escape(String(this.#item_id))}"] [data-glpi-kb-article-illustration]`
+        const articles = aside.querySelectorAll(
+            `[data-glpi-kb-article-id="${CSS.escape(String(this.#item_id))}"]`
         );
 
         // The illustration picker preview already holds a freshly rendered node
         // for the selected illustration. We clone it with a different size.
         const source = this.#getIllustrationPreviewNode();
-        for (const container of containers) {
-            if (source === null) {
-                container.replaceChildren();
-            } else {
-                const icon = source.cloneNode(true);
-                // The aside renders illustrations at size 20 (see aside.html.twig).
-                icon.setAttribute('width', '20');
-                icon.setAttribute('height', '20');
-                container.replaceChildren(icon);
+        for (const article of articles) {
+            for (const container of article.querySelectorAll('[data-glpi-kb-article-illustration]')) {
+                // Child articles are nested inside this article's element, so only
+                // update the illustration that belongs to this article.
+                if (container.closest('[data-glpi-kb-article-id]') !== article) {
+                    continue;
+                }
+                if (source === null) {
+                    container.replaceChildren();
+                } else {
+                    const icon = source.cloneNode(true);
+                    // The aside renders illustrations at size 20 (see aside.html.twig).
+                    icon.setAttribute('width', '20');
+                    icon.setAttribute('height', '20');
+                    container.replaceChildren(icon);
+                }
             }
         }
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

- Fixes #25394

The knowledge base aside renders the article tree by nesting each child article inside its parent element. When an article was renamed (or its illustration changed), the title and illustration were updated with a descendant selector `[data-glpi-kb-article-id="<id>"] [data-glpi-kb-article-title]`, which also matched every nested child. Renaming a parent (in particular the root, which contains everything) therefore visually renamed all its descendants until the page was refreshed. The database was never affected.

Both `#updateAsideTitle()` and `#updateAsideIllustration()` now update only the entry that belongs to the current article, using the same `closest(...) === article` guard already used by `AsideController::findEmptyMenus()` for the exact same nesting reason.

## Note on tests

The update methods are private and rely on the full controller and DOM, so a unit test would need significant setup. I verified the fix against the real aside DOM structure: the descendant selector matched the parent and all nested children, while the corrected logic matches only the current article. Happy to add a test where you prefer.
