### PR TITLE
Do not import LDAP location from a template with only static text

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -6252,13 +6252,33 @@ HTML;
     private static function getLdapFieldValue($map, array $res)
     {
 
+        $has_placeholder = false;
+        $has_value       = false;
+
         $ret = preg_replace_callback(
             '/%{(.*)}/U',
-            fn($matches) => $res[0][$matches[1]][0] ?? '',
+            function ($matches) use ($res, &$has_placeholder, &$has_value) {
+                $has_placeholder = true;
+                $value = $res[0][$matches[1]][0] ?? '';
+                if ($value !== '') {
+                    $has_value = true;
+                }
+                return $value;
+            },
             $map
         );
 
-        return $ret == $map ? ($res[0][$map][0] ?? '') : $ret;
+        if ($has_placeholder) {
+            // A template with placeholders is only meaningful when at least one
+            // placeholder resolved to an actual value. When every placeholder is
+            // empty, only the static text remains (e.g. "Site - ") and it must
+            // not be treated as a real value, otherwise an incomplete location
+            // would be created during LDAP synchronization.
+            return $has_value ? $ret : '';
+        }
+
+        // No placeholder: the map is a plain field name, return its raw value.
+        return $res[0][$map][0] ?? '';
     }
 
     /**

--- a/tests/functional/UserTest.php
+++ b/tests/functional/UserTest.php
@@ -2815,6 +2815,66 @@ class UserTest extends DbTestCase
         $this->assertEmpty($user2->fields['_groups'] ?? []);
     }
 
+    public static function ldapFieldValueProvider(): iterable
+    {
+        // Template with static text, attribute empty -> only static text remains,
+        // must be discarded so no incomplete location is created (issue #25427).
+        yield 'template attr empty' => [
+            'map'      => 'Site - %{physicalDeliveryOfficeName}',
+            'res'      => [0 => ['physicalDeliveryOfficeName' => ['count' => 0]]],
+            'expected' => '',
+        ];
+
+        // Template with static text, attribute absent -> same as empty.
+        yield 'template attr absent' => [
+            'map'      => 'Site - %{physicalDeliveryOfficeName}',
+            'res'      => [0 => []],
+            'expected' => '',
+        ];
+
+        // Template with static text, attribute present -> substituted value kept.
+        yield 'template attr present' => [
+            'map'      => 'Site - %{physicalDeliveryOfficeName}',
+            'res'      => [0 => ['physicalDeliveryOfficeName' => ['Office 01', 'count' => 1]]],
+            'expected' => 'Site - Office 01',
+        ];
+
+        // Bare placeholder, empty -> empty value.
+        yield 'bare placeholder empty' => [
+            'map'      => '%{physicalDeliveryOfficeName}',
+            'res'      => [0 => ['physicalDeliveryOfficeName' => ['count' => 0]]],
+            'expected' => '',
+        ];
+
+        // Multiple placeholders, one resolved -> partial value kept.
+        yield 'multi placeholder partial' => [
+            'map'      => '%{l} > %{ou}',
+            'res'      => [0 => ['l' => ['HQ', 'count' => 1], 'ou' => ['count' => 0]]],
+            'expected' => 'HQ > ',
+        ];
+
+        // Multiple placeholders, none resolved -> discarded.
+        yield 'multi placeholder all empty' => [
+            'map'      => '%{l} > %{ou}',
+            'res'      => [0 => []],
+            'expected' => '',
+        ];
+
+        // Plain field name (no placeholder) -> raw LDAP value returned.
+        yield 'plain field name' => [
+            'map'      => 'l',
+            'res'      => [0 => ['l' => ['Paris', 'count' => 1]]],
+            'expected' => 'Paris',
+        ];
+    }
+
+    #[DataProvider('ldapFieldValueProvider')]
+    public function testGetLdapFieldValue(string $map, array $res, string $expected): void
+    {
+        $result = $this->callPrivateMethod(new User(), 'getLdapFieldValue', $map, $res);
+        $this->assertSame($expected, $result);
+    }
+
     public function testIsValidUserForEntity(): void
     {
         $this->login();


### PR DESCRIPTION
Fixes #25427

## Problem

User locations can be mapped from an LDAP template, for example:

```
Entity A > Site - %{physicalDeliveryOfficeName}
```

When `physicalDeliveryOfficeName` is empty or absent, `getLdapFieldValue()` only removed the placeholder and returned the leftover static text `Site - `. That text is not empty, so it was treated as a valid value and an incomplete location (`Entity A > Site -`) was created and assigned to the user during synchronization.

## Fix

A template that contains placeholders is now considered meaningful only when at least one placeholder resolves to an actual value. When every placeholder is empty, the remaining static text is discarded and no location is created (`locations_id` stays 0).

Behaviour that does not change:

- A template with at least one resolved placeholder keeps its value, including partially resolved ones (`%{l} > %{ou}` with only `l` set returns `HQ > `).
- A plain field name with no placeholder still returns its raw LDAP value.
- A fully resolved template is unchanged.

## Tests

Added `testGetLdapFieldValue` in `tests/functional/UserTest.php` with a data provider covering: empty attribute, absent attribute, present attribute, bare placeholder, partially resolved template, fully empty multi placeholder template, and a plain field name.

Before/after on the reported case:

| Template | Attribute | Before | After |
| --- | --- | --- | --- |
| `Site - %{physicalDeliveryOfficeName}` | empty | `Site - ` (location created) | `` (no location) |
| `Site - %{physicalDeliveryOfficeName}` | `Office 01` | `Site - Office 01` | `Site - Office 01` |
