### PR TITLE
Fix Impact Analysis group save error when adding nodes without reload

### DIFF
--- a/ajax/impact.php
+++ b/ajax/impact.php
@@ -210,6 +210,7 @@ switch ($_SERVER['REQUEST_METHOD']) {
         }
 
         // Save impact compound delta
+        $compounds_mapping = [];
         $em = new ImpactCompound();
         foreach ($data['compounds'] as $id => $compound) {
             // Extract action
@@ -219,6 +220,9 @@ switch ($_SERVER['REQUEST_METHOD']) {
             switch ($action) {
                 case DELTA_ACTION_ADD:
                     $newCompoundID = $em->add($compound);
+
+                    // Map temporary frontend IDs to their database IDs.
+                    $compounds_mapping[$id] = $newCompoundID;
 
                     // Update id reference in impactitem
                     // This is needed because some nodes might have this compound
@@ -271,6 +275,7 @@ switch ($_SERVER['REQUEST_METHOD']) {
             }
         }
 
-        header('Content-Type: application/javascript');
+        header('Content-Type: application/json');
+        echo json_encode(['compounds_mapping' => $compounds_mapping]);
         break;
 }

--- a/js/impact.js
+++ b/js/impact.js
@@ -2689,6 +2689,19 @@ var GLPIImpact = {
     remapCompoundIds: function(mapping) {
         Object.keys(mapping).forEach(function(tmpId) {
             var realId = String(mapping[tmpId]);
+
+            // Update stale temp-id refs in undo/redo entries.
+            [GLPIImpact.undoStack, GLPIImpact.redoStack].forEach(function(stack) {
+                stack.forEach(function(action) {
+                    if (action.code === GLPIImpact.ACTION_ADD_COMPOUND && action.data.data.id === tmpId) {
+                        action.data.data.id = realId;
+                    }
+                    if (action.code === GLPIImpact.ACTION_MOVE && action.data.newParent === tmpId) {
+                        action.data.newParent = realId;
+                    }
+                });
+            });
+
             var compound = GLPIImpact.cy.getElementById(tmpId);
 
             // Nothing to do if the compound is no longer on the graph

--- a/js/impact.js
+++ b/js/impact.js
@@ -3923,7 +3923,9 @@ var GLPIImpact = {
                     // Sync the newly created compounds with their real database
                     // ids so the next save uses them instead of temporary ids
                     if (data && data.compounds_mapping) {
+                        // Remapping re-dirties the graph (add/remove)
                         GLPIImpact.remapCompoundIds(data.compounds_mapping);
+                        GLPIImpact.showCleanWorkspaceStatus();
                     }
                     GLPIImpact.initialState = GLPIImpact.getCurrentState();
                     $(document).trigger('impactUpdated');

--- a/js/impact.js
+++ b/js/impact.js
@@ -2682,6 +2682,40 @@ var GLPIImpact = {
     }, 100, false),
 
     /**
+    * Replace temporary compound IDs with their persisted database IDs.
+    *
+    * @param {Object} mapping temporary id -> real database id
+    */
+    remapCompoundIds: function(mapping) {
+        Object.keys(mapping).forEach(function(tmpId) {
+            var realId = String(mapping[tmpId]);
+            var compound = GLPIImpact.cy.getElementById(tmpId);
+
+            // Nothing to do if the compound is no longer on the graph
+            if (compound.length === 0) {
+                return;
+            }
+
+            // Cytoscape element IDs are immutable, so recreate the compound.
+            var newData = _.clone(compound.data());
+            newData.id = realId;
+
+            var children = compound.children();
+            GLPIImpact.cy.add({
+                group    : "nodes",
+                data     : newData,
+                classes  : compound.classes(),
+                selected : compound.selected(),
+                grabbable: compound.grabbable(),
+            });
+            children.forEach(function(child) {
+                child.move({parent: realId});
+            });
+            compound.remove();
+        });
+    },
+
+    /**
     * Remove an element from the graph
     *
     * @param {object} ele
@@ -3872,7 +3906,12 @@ var GLPIImpact = {
                 data: {
                     'impacts': JSON.stringify(GLPIImpact.computeDelta())
                 },
-                success: function(){
+                success: function(data){
+                    // Sync the newly created compounds with their real database
+                    // ids so the next save uses them instead of temporary ids
+                    if (data && data.compounds_mapping) {
+                        GLPIImpact.remapCompoundIds(data.compounds_mapping);
+                    }
                     GLPIImpact.initialState = GLPIImpact.getCurrentState();
                     $(document).trigger('impactUpdated');
                 },

--- a/tests/e2e/pages/ImpactPage.ts
+++ b/tests/e2e/pages/ImpactPage.ts
@@ -40,6 +40,7 @@ export class ImpactPage extends GlpiPage
     public readonly canvas_elements: Locator;
     public readonly view_as_list_button: Locator;
     public readonly view_as_graph_button: Locator;
+    public readonly save_button: Locator;
 
     public constructor(page: Page)
     {
@@ -51,6 +52,8 @@ export class ImpactPage extends GlpiPage
         this.canvas_elements = page.locator('.__________cytoscape_container > canvas');
         this.view_as_list_button = page.getByTitle('View as list');
         this.view_as_graph_button = page.getByTitle('View graphical representation');
+        // eslint-disable-next-line playwright/no-raw-locators
+        this.save_button = page.locator('#save_impact');
     }
 
     public async gotoComputerImpact(computer_id: number): Promise<void>

--- a/tests/e2e/specs/Asset/impact.spec.ts
+++ b/tests/e2e/specs/Asset/impact.spec.ts
@@ -57,3 +57,92 @@ test('Impact graph loads', async ({ page, profile, api }) => {
     await expect(impact_page.graph_view).toBeVisible();
     await expect(impact_page.list_view).toBeHidden();
 });
+
+test('Saving a group twice without reloading the page (#25192)', async ({ page, profile, api }) => {
+    // Regression: adding an asset to an already-saved group used to fail with
+    // "Data truncated for column 'parent_id'" (stale temp compound id).
+    await profile.set(Profiles.SuperAdmin);
+    const entities_id = getWorkerEntityId();
+    const main_asset_id = await api.createItem('Computer', { name: 'Impact main asset', entities_id });
+    const grouped_asset_a_id = await api.createItem('Computer', { name: 'Impact grouped asset A', entities_id });
+    const grouped_asset_b_id = await api.createItem('Computer', { name: 'Impact grouped asset B', entities_id });
+    const late_asset_id = await api.createItem('Computer', { name: 'Impact late asset', entities_id });
+
+    const impact_page = new ImpactPage(page);
+    await impact_page.gotoComputerImpact(main_asset_id);
+    await expect(impact_page.graph_view).toBeVisible();
+
+    // Canvas has no DOM handles, so drive the graph through GLPIImpact's own API.
+    await page.evaluate(([a, b]) => {
+        // @ts-expect-error GLPIImpact is a legacy global set by js/impact.js
+        window.GLPIImpact.addNode(a, 'Computer', { x: 200, y: 0 });
+        // @ts-expect-error GLPIImpact is a legacy global set by js/impact.js
+        window.GLPIImpact.addNode(b, 'Computer', { x: 200, y: 150 });
+    }, [grouped_asset_a_id, grouped_asset_b_id]);
+    await expect.poll(() => page.evaluate(([a, b]) => {
+        // @ts-expect-error GLPIImpact is a legacy global set by js/impact.js
+        const GLPIImpact = window.GLPIImpact;
+        return GLPIImpact.cy.getElementById(`Computer::${a}`).length
+            + GLPIImpact.cy.getElementById(`Computer::${b}`).length;
+    }, [grouped_asset_a_id, grouped_asset_b_id])).toBe(2);
+
+    // Group the two assets, same as GLPIImpact.addCompoundFromSelection().
+    const tmpCompoundId = await page.evaluate(([a, b]) => {
+        // @ts-expect-error GLPIImpact is a legacy global set by js/impact.js
+        const GLPIImpact = window.GLPIImpact;
+        const compound = GLPIImpact.cy.add({ group: 'nodes', data: { color: '#dadada', label: 'E2E group' } });
+        GLPIImpact.cy.getElementById(`Computer::${a}`).move({ parent: compound.id() });
+        GLPIImpact.cy.getElementById(`Computer::${b}`).move({ parent: compound.id() });
+        GLPIImpact.updateFlags();
+        return compound.id();
+    }, [grouped_asset_a_id, grouped_asset_b_id]);
+
+    // First save: the server creates the compound row and must report back its real id.
+    const first_save_response_promise = page.waitForResponse(
+        (resp) => resp.url().includes('ajax/impact.php') && resp.request().method() === 'POST'
+    );
+    await impact_page.save_button.click();
+    const first_save_response = await first_save_response_promise;
+    expect(first_save_response.status()).toBe(200);
+    const first_save_body = await first_save_response.json();
+    expect(Object.keys(first_save_body.compounds_mapping)).toContain(tmpCompoundId);
+    const realCompoundId = first_save_body.compounds_mapping[tmpCompoundId];
+
+    // The live graph must now reference the real id: the temporary one is gone
+    await expect.poll(() => page.evaluate((id) => {
+        // @ts-expect-error GLPIImpact is a legacy global set by js/impact.js
+        return window.GLPIImpact.cy.getElementById(id).length;
+    }, tmpCompoundId)).toBe(0);
+
+    // Add a third asset without reloading; wait for the node itself (not a
+    // count, which the compound node would already satisfy) to avoid racing addNode().
+    await page.evaluate((assetId) => {
+        // @ts-expect-error GLPIImpact is a legacy global set by js/impact.js
+        window.GLPIImpact.addNode(assetId, 'Computer', { x: 400, y: 75 });
+    }, late_asset_id);
+    await expect.poll(() => page.evaluate((assetId) => {
+        // @ts-expect-error GLPIImpact is a legacy global set by js/impact.js
+        return window.GLPIImpact.cy.getElementById(`Computer::${assetId}`).length;
+    }, late_asset_id)).toBe(1);
+
+    await page.evaluate(([assetId, parentId]) => {
+        // @ts-expect-error GLPIImpact is a legacy global set by js/impact.js
+        const GLPIImpact = window.GLPIImpact;
+        GLPIImpact.cy.getElementById(`Computer::${assetId}`).move({ parent: String(parentId) });
+        GLPIImpact.updateFlags();
+    }, [late_asset_id, realCompoundId]);
+
+    // Second save: this is where the bug reproduced (stale temp compound id).
+    const second_save_response_promise = page.waitForResponse(
+        (resp) => resp.url().includes('ajax/impact.php') && resp.request().method() === 'POST'
+    );
+    await impact_page.save_button.click();
+    const second_save_response = await second_save_response_promise;
+    expect(second_save_response.status()).toBe(200);
+
+    // The late asset ended up in the group under its real (integer) parent id
+    await expect.poll(() => page.evaluate((assetId) => {
+        // @ts-expect-error GLPIImpact is a legacy global set by js/impact.js
+        return window.GLPIImpact.cy.getElementById(`Computer::${assetId}`).data('parent');
+    }, late_asset_id)).toBe(String(realCompoundId));
+});

--- a/tests/js/impact.test.js
+++ b/tests/js/impact.test.js
@@ -290,4 +290,39 @@ describe('Impact', () => {
         // Unchanged since the first save, so it must not be re-sent as an ADD.
         expect(secondSaveDelta.compounds).not.toHaveProperty(tmpId);
     });
+    it('Regression #25192: undo can still remove a compound after its id is remapped', () => {
+        const cytoscape = require('cytoscape');
+        const cy = cytoscape({
+            elements: [
+                {group: 'nodes', data: {id: 'Computer::1'}},
+                {group: 'nodes', data: {id: 'Computer::2'}},
+                {group: 'nodes', data: {id: 'Computer::3'}},
+            ],
+        });
+        window.GLPIImpact.cy = cy;
+        window.GLPIImpact.startNode = 'Computer::1';
+
+        // Group nodes 2 and 3, same as addCompoundFromSelection().
+        const compound = cy.add({group: 'nodes', data: {color: '#dadada', label: 'Grp'}});
+        const tmpId = compound.id();
+        cy.getElementById('Computer::2').move({parent: tmpId});
+        cy.getElementById('Computer::3').move({parent: tmpId});
+
+        // Record the undo entry the way the "edit compound" dialog does on creation.
+        window.GLPIImpact.addToUndo(window.GLPIImpact.ACTION_ADD_COMPOUND, {
+            data: {id: tmpId, label: 'Grp', color: '#dadada'},
+            children: ['Computer::2', 'Computer::3'],
+        });
+
+        // Simulate the save's response remapping the compound to its real id.
+        window.GLPIImpact.remapCompoundIds({[tmpId]: 5});
+
+        // The bug: before the fix, this undo entry still pointed at the temp
+        // id and could not find the (now renamed) compound node to remove.
+        window.GLPIImpact.undo();
+
+        expect(cy.getElementById('5').length).toBe(0);
+        expect(cy.getElementById('Computer::2').isOrphan()).toBe(true);
+        expect(cy.getElementById('Computer::3').isOrphan()).toBe(true);
+    });
 });

--- a/tests/js/impact.test.js
+++ b/tests/js/impact.test.js
@@ -189,4 +189,105 @@ describe('Impact', () => {
     it('Make ID selector', () => {
         expect(window.GLPIImpact.makeIDSelector('node1')).toBe('[id=\'node1\']');
     });
+    it('Remap compound ids after save', () => {
+        const child1 = {move: jest.fn()};
+        const child2 = {move: jest.fn()};
+        const compound = {
+            length   : 1,
+            data     : () => ({id: 'tmp-abc', label: 'My group', color: '#dadada'}),
+            children : () => [child1, child2],
+            classes  : () => [],
+            selected : () => false,
+            grabbable: () => true,
+            remove   : jest.fn(),
+        };
+        const added = [];
+        window.GLPIImpact.cy = {
+            getElementById: (id) => (id === 'tmp-abc' ? compound : {length: 0}),
+            add           : (ele) => added.push(ele),
+        };
+
+        window.GLPIImpact.remapCompoundIds({'tmp-abc': 5});
+
+        expect(added).toHaveLength(1);
+        expect(added[0].group).toBe('nodes');
+        expect(added[0].data.id).toBe('5');
+        expect(added[0].data.label).toBe('My group');
+        expect(child1.move).toHaveBeenCalledWith({parent: '5'});
+        expect(child2.move).toHaveBeenCalledWith({parent: '5'});
+        expect(compound.remove).toHaveBeenCalled();
+    });
+    it('Remap compound ids preserves cytoscape element state', () => {
+        const compound = {
+            length   : 1,
+            data     : () => ({id: 'tmp-abc', label: 'My group'}),
+            children : () => [],
+            classes  : () => ['some-class'],
+            selected : () => true,
+            grabbable: () => false,
+            remove   : jest.fn(),
+        };
+        const added = [];
+        window.GLPIImpact.cy = {
+            getElementById: () => compound,
+            add           : (ele) => added.push(ele),
+        };
+
+        window.GLPIImpact.remapCompoundIds({'tmp-abc': 5});
+
+        expect(added).toHaveLength(1);
+        expect(added[0].classes).toEqual(['some-class']);
+        expect(added[0].selected).toBe(true);
+        expect(added[0].grabbable).toBe(false);
+    });
+    it('Remap compound ids ignores missing compounds', () => {
+        window.GLPIImpact.cy = {
+            getElementById: () => ({length: 0}),
+            add           : jest.fn(),
+        };
+
+        window.GLPIImpact.remapCompoundIds({'tmp-gone': 7});
+
+        expect(window.GLPIImpact.cy.add).not.toHaveBeenCalled();
+    });
+    it('Regression #25192: second save uses the real compound id, not the temporary one', () => {
+        // Real cytoscape core, not a mock — exercises the actual selector/delta logic.
+        const cytoscape = require('cytoscape');
+        const cy = cytoscape({
+            elements: [
+                {group: 'nodes', data: {id: 'Computer::1', impactitem_id: 1}},
+                {group: 'nodes', data: {id: 'Computer::2', impactitem_id: 2}},
+                {group: 'nodes', data: {id: 'Computer::3', impactitem_id: 3}},
+            ],
+        });
+        window.GLPIImpact.cy = cy;
+        window.GLPIImpact.startNode = 'Computer::1';
+        window.GLPIImpact.initialState = window.GLPIImpact.getCurrentState();
+
+        // Group nodes 2 and 3, same as addCompoundFromSelection() — cytoscape assigns the compound a random id.
+        const compound = cy.add({group: 'nodes', data: {color: '#dadada', label: 'Grp'}});
+        const tmpId = compound.id();
+        cy.getElementById('Computer::2').move({parent: tmpId});
+        cy.getElementById('Computer::3').move({parent: tmpId});
+
+        const firstSaveDelta = window.GLPIImpact.computeDelta();
+        expect(firstSaveDelta.compounds[tmpId].action).toBe(window.GLPIImpact.DELTA_ACTION_ADD);
+        expect(firstSaveDelta.items['2'].parent_id).toBe(tmpId);
+
+        // Simulate the first save's response and the save handler reacting to it.
+        window.GLPIImpact.remapCompoundIds({[tmpId]: 5});
+        window.GLPIImpact.initialState = window.GLPIImpact.getCurrentState();
+
+        // Without reloading the page, add a 3rd node straight into the group
+        cy.add({group: 'nodes', data: {id: 'Computer::4', impactitem_id: 4}});
+        cy.getElementById('Computer::4').move({parent: '5'});
+
+        const secondSaveDelta = window.GLPIImpact.computeDelta();
+
+        // The bug: before the fix this would carry the stale temp id as parent_id.
+        expect(secondSaveDelta.items['4'].parent_id).toBe('5');
+        expect(secondSaveDelta.items['4'].parent_id).not.toBe(tmpId);
+        // Unchanged since the first save, so it must not be re-sent as an ADD.
+        expect(secondSaveDelta.compounds).not.toHaveProperty(tmpId);
+    });
 });

--- a/tests/js/impact.test.js
+++ b/tests/js/impact.test.js
@@ -325,4 +325,35 @@ describe('Impact', () => {
         expect(cy.getElementById('Computer::2').isOrphan()).toBe(true);
         expect(cy.getElementById('Computer::3').isOrphan()).toBe(true);
     });
+    it('Regression #25192: save stays clean after a successful compound remap', () => {
+        document.body.innerHTML = '<button id="save_impact"></button>'
+            + '<form name="form_impact_network" action="/ajax/impact.php"></form>';
+
+        const cytoscape = require('cytoscape');
+        const cy = cytoscape({elements: [{group: 'nodes', data: {id: 'Computer::1'}}]});
+        window.GLPIImpact.cy = cy;
+        window.GLPIImpact.startNode = 'Computer::1';
+
+        // Wire the same add/remove -> dirty handler the real graph uses.
+        cy.on('add remove', window.GLPIImpact.onChange);
+
+        const compound = cy.add({group: 'nodes', data: {color: '#dadada', label: 'Grp'}});
+        const tmpId = compound.id();
+        window.GLPIImpact.initialState = window.GLPIImpact.getCurrentState();
+
+        const originalAjax = window.$.ajax;
+        window.$.ajax = function(options) {
+            options.success({compounds_mapping: {[tmpId]: 5}});
+        };
+
+        window.GLPIImpact.initToolbar();
+        window.$(window.GLPIImpact.selectors.save).trigger('click');
+
+        window.$.ajax = originalAjax;
+
+        // The bug: remapCompoundIds() adds/removes graph elements, which
+        // marks the workspace dirty again right after the save succeeded.
+        expect(window.$(window.GLPIImpact.selectors.save).hasClass('dirty')).toBe(false);
+        expect(window.$(window.GLPIImpact.selectors.save).hasClass('clean')).toBe(true);
+    });
 });


### PR DESCRIPTION
## Description

Fixes an issue where saving an Impact Analysis immediately after creating a group could fail when adding nodes without reloading the page.

The frontend uses temporary IDs for newly created Cytoscape compounds, while the backend persists them with database IDs. The temporary IDs could therefore be sent as `parent_id` on subsequent saves.

## Changes

* Return a mapping between temporary and persisted compound IDs from `ajax/impact.php`.
* Remap Cytoscape compound IDs after a successful save.
* Preserve compound state when replacing the temporary node.
* Update undo/redo entries when remapping compound IDs.
* Preserve the clean save state after the compound ID remapping.
* Add an E2E regression test covering two consecutive saves without page reload.
* Add unit/integration tests for compound ID remapping and state handling.
* Add the save button locator to `ImpactPage`.

## Testing

* Added a regression test for #25192.
* Added tests covering:

  * compound ID remapping
  * state preservation
  * missing compounds
  * subsequent saves using the persisted compound ID
  * undo/redo after compound ID remapping
  * keeping the save state clean after a successful save

Fixes #25192
